### PR TITLE
JWKSet Caching and JOSESignature abstraction

### DIFF
--- a/examples/KS256-JWD-Sign-using-JWK.js
+++ b/examples/KS256-JWD-Sign-using-JWK.js
@@ -1,0 +1,65 @@
+const crypto = require('@trust/webcrypto')
+const { JWD } = require('../src')
+const JWKSetCache = require('../src/JWKSetCache')
+const base64url = require('base64url')
+const keyto = require('@trust/keyto')
+const { JWK } = require('@trust/jwk')
+const nock = require('nock')
+
+const privateHex = '57eba9c003d930e8233f502d8f0cc552e7ee75942b273a41c26d3bbb97b924e2'
+const key = keyto.from(privateHex, 'blk')
+const privateJwk = key.toJwk('private')
+privateJwk.key_ops = ['sign']
+const publicJwk = key.toJwk('public')
+publicJwk.key_ops = ['verify']
+const cache = new JWKSetCache()
+
+nock('http://example.com')
+  .get('/jwks')
+  .reply(200, {
+    keys: [
+      { kty: 'EC',
+        crv: 'K-256',
+        x: '8f0rIY4UhA-pM1MpephSGbK2zlejAbQp8kggZxCbYmc',
+        y: 'HmN6hSXf8TqnCchI0VZ0cf110ftuWLwfFJIAjwx_a0Q',
+        alg: 'KS256',
+        key_ops: [ 'verify' ] }
+    ]
+  })
+
+let privateKey, publicKey
+
+let payload = { iss: 'http://example.com', exp: 123456789, iat: 123456789 }
+let header = { typ: 'JWS', alg: 'KS256', jku: 'http://example.com/jwks' }
+
+
+Promise.all([
+  JWK.importKey(privateJwk, { alg: header.alg }),
+  JWK.importKey(publicJwk, { alg: header.alg }),
+])
+
+  // use key with JWA to create a signature
+  .then(keypair => {
+    let [prv, pub] = keypair
+    privateKey = prv
+    publicKey = pub
+
+    let serialized = JSON.stringify({ payload: base64url(JSON.stringify(payload)), protected: base64url(JSON.stringify(header)), signature: 'signaturesignaturesignature'})
+
+    return JWD.encode({ protected: header, jwk: privateKey, payload, cache }, { serialization: 'document' })
+  })
+
+  // verify the signature
+  .then(token => {
+    return JWD.verify({ serialized: token, result: 'instance', cache })
+  })
+
+  // look at the output
+  .then(token => {
+    console.error(`TOKEN FINAL VERIFICATION RESULT:`, token.verified)
+    console.error(`TOKEN`)
+    console.log(JSON.stringify(token, null, 2))
+  })
+
+  // look at the out
+  .catch(console.log)

--- a/examples/KS256-JWD-Sign.js
+++ b/examples/KS256-JWD-Sign.js
@@ -27,7 +27,7 @@ nock('http://example.com')
 let privateKey, publicKey
 
 let payload = { iss: 'http://example.com', exp: 123456789, iat: 123456789 }
-let header = { typ: 'JWS', alg: 'KS256', jku: 'http://example.com/jwks' }
+let header = { jku: 'http://example.com/jwks' }
 
 
 Promise.all([
@@ -41,14 +41,12 @@ Promise.all([
     privateKey = prv
     publicKey = pub
 
-    let serialized = JSON.stringify({ payload: base64url(JSON.stringify(payload)), protected: base64url(JSON.stringify(header)), signature: 'signaturesignaturesignature'})
-
-    return JWD.encode({ protected: header, cryptoKey: privateKey, alg: 'KS256', payload, cache }, { serialization: 'document' })
+    return JWD.encode({ protected: header, cryptoKey: privateKey, payload, alg: 'KS256' }, { serialization: 'document' })
   })
 
   // verify the signature
   .then(token => {
-    return JWD.verify({ serialized: token, result: 'instance', cache })
+    return JWD.verify(token, { result: 'instance' })
   })
 
   // look at the output

--- a/examples/KS256-JWD-Sign.js
+++ b/examples/KS256-JWD-Sign.js
@@ -1,0 +1,62 @@
+const crypto = require('@trust/webcrypto')
+const { JWD } = require('../src')
+const JWKSetCache = require('../src/JWKSetCache')
+const base64url = require('base64url')
+const keyto = require('@trust/keyto')
+const nock = require('nock')
+
+const privateHex = '57eba9c003d930e8233f502d8f0cc552e7ee75942b273a41c26d3bbb97b924e2'
+const key = keyto.from(privateHex, 'blk')
+const privateJwk = key.toJwk('private')
+const publicJwk = key.toJwk('public')
+const cache = new JWKSetCache()
+
+nock('http://example.com')
+  .get('/jwks')
+  .reply(200, {
+    keys: [
+      { kty: 'EC',
+        crv: 'K-256',
+        x: '8f0rIY4UhA-pM1MpephSGbK2zlejAbQp8kggZxCbYmc',
+        y: 'HmN6hSXf8TqnCchI0VZ0cf110ftuWLwfFJIAjwx_a0Q',
+        alg: 'KS256',
+        key_ops: [ 'verify' ] }
+    ]
+  })
+
+let privateKey, publicKey
+
+let payload = { iss: 'http://example.com', exp: 123456789, iat: 123456789 }
+let header = { typ: 'JWS', alg: 'KS256', jku: 'http://example.com/jwks' }
+
+
+Promise.all([
+  crypto.subtle.importKey('jwk', privateJwk, { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } }, true, ['sign']),
+  crypto.subtle.importKey('jwk', publicJwk, { name: 'ECDSA', namedCurve: 'K-256', hash: { name: 'SHA-256' } }, true, ['verify']),
+])
+
+  // use key with JWA to create a signature
+  .then(keypair => {
+    let [prv, pub] = keypair
+    privateKey = prv
+    publicKey = pub
+
+    let serialized = JSON.stringify({ payload: base64url(JSON.stringify(payload)), protected: base64url(JSON.stringify(header)), signature: 'signaturesignaturesignature'})
+
+    return JWD.encode({ protected: header, cryptoKey: privateKey, alg: 'KS256', payload, cache }, { serialization: 'document' })
+  })
+
+  // verify the signature
+  .then(token => {
+    return JWD.verify({ serialized: token, result: 'instance', cache })
+  })
+
+  // look at the output
+  .then(token => {
+    console.error(`TOKEN FINAL VERIFICATION RESULT:`, token.verified)
+    console.error(`TOKEN`)
+    console.log(JSON.stringify(token, null, 2))
+  })
+
+  // look at the out
+  .catch(console.log)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,43 +2,68 @@
   "name": "@trust/jwt",
   "version": "0.4.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@trust/json-document": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@trust/json-document/-/json-document-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/@trust/json-document/-/json-document-0.1.4.tgz",
       "integrity": "sha1-sgI7HhRbp2hb0fNux7aRKJQAc+k="
     },
     "@trust/jwa": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@trust/jwa/-/jwa-0.4.5.tgz",
-      "integrity": "sha1-6ASw6MMIxsDWaze9Wm56sb19E8I="
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@trust/jwa/-/jwa-0.4.6.tgz",
+      "integrity": "sha512-wJRMdJsbfU2/+talpkD+y3sI/aJOBRgo8/QI3BMqI4zEfieM2fppkjDO6XAa9luoEcR0PNX0/EtqIQJMC2RMVA==",
+      "requires": {
+        "@trust/webcrypto": "0.5.0",
+        "base64url": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+        "text-encoding": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz"
+      }
     },
     "@trust/jwk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@trust/jwk/-/jwk-0.3.0.tgz",
-      "integrity": "sha1-SyWjSofYpUgBKBCE+F2ppH7WmmM="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@trust/jwk/-/jwk-0.3.1.tgz",
+      "integrity": "sha512-c72F/BtKu9njIzcNJQFJvopTuwb1At8FYaY31OSn50NQvdbkUHaE65DcT9Pk6G+TCojgqiBM57Fj9u2PzglooA==",
+      "requires": {
+        "@trust/jwa": "0.4.6",
+        "@trust/webcrypto": "0.5.0",
+        "base64url": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+        "node-fetch": "1.7.3",
+        "sift": "5.0.0"
+      }
     },
     "@trust/keyto": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-0.3.1.tgz",
-      "integrity": "sha1-Q96AKTD4JvxZj/73VtqBR42GEaM="
+      "integrity": "sha1-Q96AKTD4JvxZj/73VtqBR42GEaM=",
+      "requires": {
+        "asn1.js": "4.9.1",
+        "base64url": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+        "elliptic": "6.4.0"
+      }
     },
     "@trust/webcrypto": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@trust/webcrypto/-/webcrypto-0.4.0.tgz",
-      "integrity": "sha1-zIcSyomn5x01P877ZrJwemec9jU="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@trust/webcrypto/-/webcrypto-0.5.0.tgz",
+      "integrity": "sha1-XURt2vp1WIJDVuhSQqMdlGj9ayE=",
+      "requires": {
+        "@trust/keyto": "0.3.1",
+        "base64url": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+        "node-rsa": "0.4.2",
+        "text-encoding": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz"
+      }
     },
     "abbrev": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
     "abstract-leveldown": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.2.tgz",
-      "integrity": "sha512-6RmGuGZSsvwIYS9otANM+Rie7/6UNdE0IbxwUiXFjXmjHNCJZEjyX2Pltl5BvIYszLODlsnXtyA7A7Ujlca4Gw==",
-      "dev": true
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+      "dev": true,
+      "requires": {
+        "xtend": "4.0.1"
+      }
     },
     "after": {
       "version": "0.8.2",
@@ -47,10 +72,13 @@
       "dev": true
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+      }
     },
     "ansi": {
       "version": "0.3.1",
@@ -63,6 +91,10 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -74,13 +106,25 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+          }
         }
       }
     },
@@ -91,8 +135,7 @@
       "dev": true
     },
     "argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "version": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
       "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
       "dev": true
     },
@@ -100,77 +143,100 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
       "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "array-like-slice-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-like-slice-x/-/array-like-slice-x-1.1.0.tgz",
+      "integrity": "sha512-hIE4qTc8NUWgHwIGIIHTgDK+gK8zw20zgg/qZkrwwwM8R1i94i96Olr3RmP0GfQF5ffqehvAcutdTsyWj1XSdg==",
+      "dev": true,
+      "requires": {
+        "split-if-boxed-bug-x": "1.0.0",
+        "to-integer-x": "2.1.0",
+        "to-length-x": "2.1.0",
+        "to-object-x": "1.4.1",
+        "validate.io-undefined": "1.0.3"
+      }
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1.js": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA="
+      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "1.0.0"
+      }
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "attempt-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.0.tgz",
+      "integrity": "sha512-0ZFSBkMhMwsvNr/t7f7fw7rIB9060k6rEWd40A5PIiCddWuvI8kbKuNtF9rYy/74Ef0ORY7cwJfZ2gJxZxGCdA==",
+      "dev": true,
+      "requires": {
+        "array-like-slice-x": "1.1.0"
+      }
+    },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "babylon": {
-      "version": "7.0.0-beta.21",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.21.tgz",
-      "integrity": "sha512-fjhepTXb+WS5Iyu+DATZA5maLpuqaGckPnCgmnIWG80Xkm4SxA1mdTsBHMvaMSbdSKj/4Pocd4pUkI4qgL2wwQ==",
+      "version": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.20.tgz",
+      "integrity": "sha1-fbxwzIjeEzNAZv5SAODvqjDASQ4=",
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "base64url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
       "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+      }
     },
     "bindings": {
       "version": "1.2.1",
@@ -183,6 +249,9 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
       "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
       "dev": true,
+      "requires": {
+        "readable-stream": "2.0.6"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -194,7 +263,15 @@
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
         }
       }
     },
@@ -202,30 +279,36 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
       "dev": true
     },
     "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "version": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      }
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+      }
     },
     "brorand": {
       "version": "1.1.0",
@@ -233,8 +316,7 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
@@ -242,35 +324,47 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
       "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-array-buffer-x": "1.7.0"
+      }
     },
     "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "catharsis": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+      "version": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "underscore-contrib": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz"
+      }
     },
     "chai": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
+      "version": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
       "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+        "check-error": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+        "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
+        "get-func-name": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+        "pathval": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
+      }
     },
     "chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
-      "dev": true
+      "version": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
+      "dev": true,
+      "requires": {
+        "check-error": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz"
+      }
     },
     "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
@@ -287,90 +381,103 @@
       "dev": true
     },
     "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "codecov": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-2.3.0.tgz",
+      "version": "https://registry.npmjs.org/codecov/-/codecov-2.3.0.tgz",
       "integrity": "sha1-rSWixuBELRN0DZ1N27mj4nFDMPQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argv": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "urlgrey": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz"
+      }
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+      }
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+      }
     },
     "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+      }
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.30"
+      }
     },
     "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+      },
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+      }
     },
     "deep-eql": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
+      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
       "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
       "dev": true,
+      "requires": {
+        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz"
+      },
       "dependencies": {
         "type-detect": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
           "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
           "dev": true
         }
       }
     },
     "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
@@ -384,11 +491,13 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
       "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "2.6.3"
+      }
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
@@ -399,15 +508,13 @@
       "dev": true
     },
     "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
     "dirty-chai": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
-      "integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
+      "version": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
+      "integrity": "sha1-ayFi7xf3lDWJ2oQKvJbnW9oBr/M=",
       "dev": true
     },
     "double-ended-queue": {
@@ -421,49 +528,81 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+      }
     },
     "elliptic": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8="
+      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+        "brorand": "1.1.0",
+        "hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+        "hmac-drbg": "1.0.1",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
     },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
     },
     "end-of-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      }
     },
     "end-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/end-stream/-/end-stream-0.1.0.tgz",
       "integrity": "sha1-MgA/P0OKKwFDFoE3+PpumGbIHtU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "write-stream": "0.4.3"
+      }
     },
     "errno": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
+      "requires": {
+        "prr": "0.0.0"
+      },
       "dependencies": {
         "prr": {
           "version": "0.0.0",
@@ -477,23 +616,35 @@
       "version": "0.10.30",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
       "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30"
+      }
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -501,7 +652,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/execspawn/-/execspawn-1.0.1.tgz",
       "integrity": "sha1-gob53efOzeeQX73ATiTzaPI/jaY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "util-extend": "1.0.3"
+      }
     },
     "expand-template": {
       "version": "1.1.0",
@@ -510,14 +664,12 @@
       "dev": true
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
     "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
@@ -528,26 +680,30 @@
       "dev": true
     },
     "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
+      }
     },
     "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz"
+      }
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -555,7 +711,13 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "rimraf": "2.6.2"
+      }
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -567,23 +729,30 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
       "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi": "0.3.1",
+        "has-unicode": "2.0.1",
+        "lodash.pad": "4.5.1",
+        "lodash.padend": "4.6.1",
+        "lodash.padstart": "4.6.1"
+      }
     },
     "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+      },
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -593,19 +762,34 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/ghreleases/-/ghreleases-1.0.6.tgz",
       "integrity": "sha512-uySVPT5T9uP1xeWR7nl3WD8/JjJJXAph/0zdgUQJ7ovFpL3rxBT/HT0sO6w0GDWCj2gwXvzxBKrIeJAgBhs+fw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "after": "0.8.2",
+        "ghrepos": "2.0.0",
+        "ghutils": "3.2.1",
+        "simple-mime": "0.1.0",
+        "url-template": "2.0.8",
+        "xtend": "4.0.1"
+      }
     },
     "ghrepos": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ghrepos/-/ghrepos-2.0.0.tgz",
       "integrity": "sha1-1m6unZijtTmORg1tt+EKdCaS6Bs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ghutils": "3.2.1"
+      }
     },
     "ghutils": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ghutils/-/ghutils-3.2.1.tgz",
       "integrity": "sha1-T87f+sk1/KzgbhKhfGF04sKf/k8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonist": "1.3.0",
+        "xtend": "4.0.1"
+      }
     },
     "github-from-package": {
       "version": "0.0.0",
@@ -614,58 +798,81 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true
+      "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "requires": {
+        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+      }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
     "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
     "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
       "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
       "dev": true
     },
     "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "dev": true,
+      "requires": {
+        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+        "har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+      }
+    },
+    "has-boxed-string-x": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-boxed-string-x/-/has-boxed-string-x-1.0.1.tgz",
+      "integrity": "sha512-Pik18dmNOFZZAvai2l+NAjTY708Ou9Dvb6tsd+QFJv++KbAbOoTZ4GbBhSnU983l7hrNuGW50qSf1GcExq8GhQ==",
       "dev": true
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "has-own-property-x": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz",
+      "integrity": "sha512-1L+yagK0h8YedH/bkwoiY+PdCr6SadmjgMudQ2SjiPdxXGdPhFybpln3yJ41EpuETz33ITNxTMHdYfeM79W03Q==",
+      "dev": true,
+      "requires": {
+        "to-object-x": "1.4.1",
+        "to-property-key-x": "2.0.1"
+      }
+    },
     "has-symbol-support-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.0.tgz",
-      "integrity": "sha512-F1NtLDtW9NyUrS3faUcI1yVFHCTXyzPb1jfrZBQi5NHxFPlXxZnFLFGzfA2DsdmgCxv2MZ0+bfcgC4EZTmk4SQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
+      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA==",
       "dev": true
     },
     "has-to-string-tag-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.0.tgz",
-      "integrity": "sha512-R3OdOP9j6AH5hS1yXeu9wAS+iKSZQx/CC6aMdN6WiaqPlBoA2S+47MtoMsZgKr2m0eAJ+73WWGX0RaFFE5XWKA==",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "1.4.1"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -674,51 +881,75 @@
       "dev": true
     },
     "hash.js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA=="
+      "version": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "1.0.0"
+      }
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE="
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
+      }
     },
     "hyperquest": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
       "integrity": "sha1-OeH+9miI3Hzg3sbA3YFPb8iUStU=",
       "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2",
+        "through2": "0.6.5"
+      },
       "dependencies": {
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.33",
+            "xtend": "4.0.1"
+          }
         }
       }
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "immediate": {
       "version": "3.0.6",
@@ -727,14 +958,16 @@
       "dev": true
     },
     "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
@@ -744,22 +977,90 @@
       "dev": true
     },
     "is-array-buffer-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.4.0.tgz",
-      "integrity": "sha512-0GQe5QPJBh9Lmt+PFP9O2BQvwQ1cMPohgL9vRuNIjb5cYi9HeeJESCJeG8lHziniVR+3VolF8YRz6LlfgNpb0A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
+      "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
+      "dev": true,
+      "requires": {
+        "attempt-x": "1.1.0",
+        "has-to-string-tag-x": "1.4.1",
+        "is-object-like-x": "1.5.1",
+        "object-get-own-property-descriptor-x": "3.2.0",
+        "to-string-tag-x": "1.4.1"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
+    },
+    "is-falsey-x": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.0.tgz",
+      "integrity": "sha512-KTX7u0md86P+4xke6DWD9g9cK+P+9ADK+kckLzBOj6LvAm8CtYJ9MiDtKoBHCXXzGMK778iSPS+2iFSmS1VrRA==",
+      "dev": true
+    },
+    "is-finite-x": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.1.tgz",
+      "integrity": "sha512-moPNeMjJ81/DSTmQbZrwAblpgi8JK/7jmb8VaZIpyoTZlVtpZb4M61gmi5TY6fizYnVE5dahZ0K+9nMi1Q05dw==",
+      "dev": true,
+      "requires": {
+        "is-nan-x": "1.0.1"
+      }
     },
     "is-function-x": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.1.0.tgz",
-      "integrity": "sha512-QYIql/y+5SRlQyMCO93R+Gq3mPXkSy49MxsEuSu1DCoEx3UUuw+kbsPn7tGf1oStPchZBAqe20/xfqS1wZGSlQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.1.1.tgz",
+      "integrity": "sha512-klx9TzyFpj8D1aNMSHi6y0+inn2gOmtPQQkVkxTVv5Oa8YNWFJJ5QpIe09p79zHxeJ5FzyA7Ms2vQH2PLXt4OQ==",
+      "dev": true,
+      "requires": {
+        "has-to-string-tag-x": "1.4.1",
+        "is-primitive": "2.0.0",
+        "normalize-space-x": "1.3.3",
+        "replace-comments-x": "1.0.3",
+        "to-string-tag-x": "1.4.1"
+      }
+    },
+    "is-index-x": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz",
+      "integrity": "sha512-BJ7vtw0jvcjBX4UsT7KkpZUliAMX3vJugZimDKy4W6ilGDtvUZ8nYsYnROVrrsjNjg5LJ3MN9NvyRVALfDW/wQ==",
+      "dev": true,
+      "requires": {
+        "math-clamp-x": "1.1.0",
+        "max-safe-integer": "1.0.1",
+        "safe-to-string-x": "2.0.1",
+        "to-integer-x": "2.1.0",
+        "to-number-x": "1.1.0"
+      }
+    },
+    "is-nan-x": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.1.tgz",
+      "integrity": "sha512-VfNJgfuT8USqKCYQss8g7sFvCzDnL+OOVMQoXhVoulZAyp0ZTj3oyZaaPrn2dxepAkKSQI2BiKHbBabX1DqVtw==",
       "dev": true
     },
+    "is-nil-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz",
+      "integrity": "sha512-cfTKWI5iSR04SSCzzugTH5tS2rYG7kwI8yl/AqWkyuxZ7k55cbA47Y7Lezdg1N9aaELd+UxLg628bdQeNQ6BUw==",
+      "dev": true,
+      "requires": {
+        "lodash.isnull": "3.0.0",
+        "validate.io-undefined": "1.0.3"
+      }
+    },
     "is-object-like-x": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.0.tgz",
-      "integrity": "sha512-8nt2Uf/75/JWi0zL4cSesOkCKW/rcFtNiYi5776ny/LJCchPqheKnx/328MPUaN3uYzkSZKNjo7zbTGMpBfthw==",
-      "dev": true
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz",
+      "integrity": "sha512-AtUeYE4Xs8EbuHuG6yBHiLdIlWRPPFidcIs3JE6PJZ/mzUQFOK8X5J1OA+3cVi0rlrdUCjiX52obtCV2hxs+HA==",
+      "dev": true,
+      "requires": {
+        "is-function-x": "3.1.1",
+        "is-primitive": "2.0.0"
+      }
     },
     "is-primitive": {
       "version": "2.0.0",
@@ -785,75 +1086,83 @@
       "dev": true
     },
     "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "js2xmlparser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+      "version": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "xmlcreate": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz"
+      }
     },
     "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
     },
     "jsdoc": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.4.tgz",
-      "integrity": "sha512-VmTw0J+2L16IxAe0JSDSAcH0F+DbZxaj8wN1AjHtKMQU/hO0ciIl5ZE93XqrrFIbknobuqHKJCXZj6+Hk57MjA==",
-      "dev": true
+      "version": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.4.tgz",
+      "integrity": "sha1-zu73xLrEM1yxD/QeOg9Yk5pTRCg=",
+      "dev": true,
+      "requires": {
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.20.tgz",
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+        "catharsis": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "js2xmlparser": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+        "klaw": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+        "marked": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "requizzle": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+        "taffydb": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+      }
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+      }
     },
     "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
     "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
@@ -861,27 +1170,39 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-1.3.0.tgz",
       "integrity": "sha1-wMdLle8clSA4YZsp76UgscyYdVY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bl": "1.0.3",
+        "hyperquest": "1.2.0",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "xtend": "4.0.1"
+      }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+        "verror": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+      },
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "klaw": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
       "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      }
     },
     "level-codec": {
       "version": "7.0.0",
@@ -893,31 +1214,59 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
       "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "errno": "0.1.4"
+      }
     },
     "level-iterator-stream": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "level-errors": "1.0.5",
+        "readable-stream": "1.0.33",
+        "xtend": "4.0.1"
+      }
     },
     "level-write-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/level-write-stream/-/level-write-stream-1.0.0.tgz",
       "integrity": "sha1-P3+7Z5pVE3wP6zA97nZuEu4Twdw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "end-stream": "0.1.0"
+      }
     },
     "leveldown": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.5.0.tgz",
       "integrity": "sha1-a408vqekqJqkdERgfXNYIT5vy4E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "2.6.3",
+        "bindings": "1.2.1",
+        "fast-future": "1.0.2",
+        "nan": "2.4.0",
+        "prebuild": "4.5.0"
+      }
     },
     "levelup": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.8.tgz",
       "integrity": "sha1-+0QsSI776hBD9+uZKaeSp0+9HaY=",
       "dev": true,
+      "requires": {
+        "deferred-leveldown": "1.2.2",
+        "level-codec": "6.1.0",
+        "level-errors": "1.0.5",
+        "level-iterator-stream": "1.3.1",
+        "prr": "1.0.1",
+        "semver": "5.1.1",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "level-codec": {
           "version": "6.1.0",
@@ -937,59 +1286,62 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "immediate": "3.0.6"
+      }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
     "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+      }
     },
     "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+        "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+      }
     },
     "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
@@ -1000,10 +1352,14 @@
       "dev": true
     },
     "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+      }
     },
     "lodash.pad": {
       "version": "4.5.1",
@@ -1024,8 +1380,7 @@
       "dev": true
     },
     "lolex": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "version": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
       "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
       "dev": true
     },
@@ -1036,9 +1391,33 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "version": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
       "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "dev": true
+    },
+    "math-clamp-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz",
+      "integrity": "sha512-c7Hxz6Ji4HtwUSMI1HU3Y7pcWQyuINlnCeE1675ZfNbEELFHeqHnEQXrWB7kLiiNTMi6QM38txFAfKq2IYqZpQ==",
+      "dev": true,
+      "requires": {
+        "to-number-x": "1.1.0"
+      }
+    },
+    "math-sign-x": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz",
+      "integrity": "sha512-3shFG0Ea5vOMCgQCrylyzu3POQRTvvaclb4VArnICToTgshMfA4Dlb9q9lZO1SD/rUD9mOTJZ7dTtlfCq7I91A==",
+      "dev": true,
+      "requires": {
+        "is-nan-x": "1.0.1",
+        "to-number-x": "1.1.0"
+      }
+    },
+    "max-safe-integer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
+      "integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA=",
       "dev": true
     },
     "memdown": {
@@ -1046,12 +1425,22 @@
       "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.2.4.tgz",
       "integrity": "sha1-zZo0qvB01TRFonEQjrS43U7A8n8=",
       "dev": true,
+      "requires": {
+        "abstract-leveldown": "2.4.1",
+        "functional-red-black-tree": "1.0.1",
+        "immediate": "3.2.3",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "ltgt": "2.1.3"
+      },
       "dependencies": {
         "abstract-leveldown": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
           "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "xtend": "4.0.1"
+          }
         },
         "immediate": {
           "version": "3.2.3",
@@ -1068,16 +1457,17 @@
       }
     },
     "mime-db": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
       "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
       "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -1090,32 +1480,71 @@
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+      }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
     },
     "mocha": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
-      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
-      "dev": true
+      "version": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha1-EyhWfScX+ZcDD4AGI0vOm4zXJGU=",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+        "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
@@ -1126,56 +1555,102 @@
       "dev": true
     },
     "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "version": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
     "nock": {
-      "version": "9.0.14",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.14.tgz",
+      "version": "https://registry.npmjs.org/nock/-/nock-9.0.14.tgz",
       "integrity": "sha1-IhFVAlMXPOKYvNifyoJeg4E8pys=",
       "dev": true,
+      "requires": {
+        "chai": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "deep-equal": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "propagate": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+      },
       "dependencies": {
         "chai": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
           "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+            "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+            "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+          }
         },
         "deep-eql": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
           "dev": true,
+          "requires": {
+            "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+          },
           "dependencies": {
             "type-detect": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
               "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
               "dev": true
             }
           }
         },
         "type-detect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
           "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
           "dev": true
         }
       }
     },
     "node-fetch": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
-      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig=="
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
     },
     "node-gyp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "npmlog": "2.0.4",
+        "osenv": "0.1.4",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "rimraf": "2.6.2",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+      },
       "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -1188,12 +1663,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/node-ninja/-/node-ninja-1.0.2.tgz",
       "integrity": "sha1-IKCeV7kuLfWRmT1L8JisPnJwYrY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "npmlog": "2.0.4",
+        "osenv": "0.1.4",
+        "path-array": "1.0.1",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "rimraf": "2.6.2",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+        "tar": "2.2.1",
+        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+      }
     },
     "node-rsa": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.4.2.tgz",
-      "integrity": "sha1-1jkXKewWqDDtWjgEKzFX0tXXJTA="
+      "integrity": "sha1-1jkXKewWqDDtWjgEKzFX0tXXJTA=",
+      "requires": {
+        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+      }
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -1202,1113 +1696,1648 @@
       "dev": true
     },
     "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+      }
     },
     "normalize-space-x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-1.3.2.tgz",
-      "integrity": "sha512-90FkeM1xmKZ47Kl0JY5PhTQCSfxxxPwqQyv744KRyoHi4Ulp9g9uWoygJR/Rdv1oklABuFnwgej1Y+fb+2pQjA==",
-      "dev": true
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-1.3.3.tgz",
+      "integrity": "sha512-9q953GogZSw2Ba1Pj3rI9T3xIPq5PtQBXEX2T/nKCaRuj8scAicXCsYMBKfKDtohTWaKGrZmBF9h53GJzfZ8TQ==",
+      "dev": true,
+      "requires": {
+        "trim-x": "1.0.3",
+        "white-space-x": "2.0.3"
+      }
     },
     "npmlog": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
       "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi": "0.3.1",
+        "are-we-there-yet": "1.1.4",
+        "gauge": "1.2.7"
+      }
     },
     "nyc": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.1.0.tgz",
+      "version": "https://registry.npmjs.org/nyc/-/nyc-11.1.0.tgz",
       "integrity": "sha1-1rPF4WiSolr2MTi6SEZ2qooi7ac=",
       "dev": true,
+      "requires": {
+        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "caching-transform": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+        "debug-log": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+        "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+        "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+        "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+        "istanbul-lib-hook": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+        "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
+        "istanbul-lib-report": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+        "istanbul-lib-source-maps": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+        "istanbul-reports": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+        "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+        "merge-source-map": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+        "spawn-wrap": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.8.tgz",
+        "test-exclude": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+        "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+      },
       "dependencies": {
         "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+          }
         },
         "amdefine": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "append-transform": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
+          }
         },
         "archy": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arr-diff": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+          }
         },
         "arr-flatten": {
-          "version": "1.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+          "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
           "dev": true
         },
         "array-unique": {
-          "version": "0.2.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "arrify": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "async": {
-          "version": "1.5.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "babel-code-frame": {
-          "version": "6.22.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+          }
         },
         "babel-generator": {
-          "version": "6.25.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+          "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+          "dev": true,
+          "requires": {
+            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+            "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+            "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+          }
         },
         "babel-messages": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+          }
         },
         "babel-runtime": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+          "dev": true,
+          "requires": {
+            "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+            "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+          }
         },
         "babel-template": {
-          "version": "6.25.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+          "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
         },
         "babel-traverse": {
-          "version": "6.25.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+          "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "globals": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+            "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
         },
         "babel-types": {
-          "version": "6.25.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+          "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+          }
         },
         "babylon": {
-          "version": "6.17.4",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+          "integrity": "sha1-Pot0AriNIsNCPhN6FXeIOxX/hpo=",
           "dev": true
         },
         "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "dev": true,
+          "requires": {
+            "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+          }
         },
         "braces": {
-          "version": "1.8.5",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+          }
         },
         "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "caching-transform": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "dev": true,
+          "requires": {
+            "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "write-file-atomic": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz"
+          }
         },
         "camelcase": {
-          "version": "1.2.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+          }
+        },
+        "chalk": {
+          "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+          }
+        },
+        "cliui": {
+          "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+          },
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
             }
           }
         },
         "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "commondir": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
-          "version": "1.5.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+          "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
           "dev": true
         },
         "core-js": {
-          "version": "2.4.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
           "dev": true
         },
         "cross-spawn": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+          }
         },
         "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+          }
         },
         "debug-log": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "default-require-extensions": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "dev": true,
+          "requires": {
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+          }
         },
         "detect-indent": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "dev": true,
+          "requires": {
+            "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+          }
         },
         "error-ex": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "dev": true,
+          "requires": {
+            "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+          }
         },
         "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "esutils": {
-          "version": "2.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "execa": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+            "get-stream": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+            "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "npm-run-path": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "p-finally": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "strip-eof": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
+          }
         },
         "expand-brackets": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+          }
         },
         "expand-range": {
-          "version": "1.8.2",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+          "dev": true,
+          "requires": {
+            "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+          }
         },
         "extglob": {
-          "version": "0.3.2",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
         },
         "filename-regex": {
-          "version": "2.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
           "dev": true
         },
         "fill-range": {
-          "version": "2.2.3",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+          "dev": true,
+          "requires": {
+            "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+          }
         },
         "find-cache-dir": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "dev": true,
+          "requires": {
+            "commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+          }
         },
         "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
+          }
         },
         "for-in": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         },
         "for-own": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "dev": true,
+          "requires": {
+            "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+          }
         },
         "foreground-child": {
-          "version": "1.5.6",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+          }
         },
         "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
-          "version": "2.3.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "dev": true,
+          "requires": {
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          }
         },
         "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
         },
         "glob-base": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+          "dev": true,
+          "requires": {
+            "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          }
         },
         "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          }
         },
         "globals": {
-          "version": "9.18.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
           "dev": true
         },
         "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
-          "version": "4.0.10",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+          "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
           "dev": true,
+          "requires": {
+            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+            "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz"
+          },
           "dependencies": {
             "source-map": {
-              "version": "0.4.4",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true,
+              "requires": {
+                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+              }
             }
           }
         },
         "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+          }
         },
         "has-flag": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.5.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
           "dev": true
         },
         "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         },
         "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+          }
         },
         "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
-          "version": "1.1.5",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
           "dev": true
         },
         "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "dev": true,
+          "requires": {
+            "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+          }
         },
         "is-dotfile": {
-          "version": "1.0.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
           "dev": true
         },
         "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+          "dev": true,
+          "requires": {
+            "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+          }
         },
         "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-extglob": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-finite": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+          }
         },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+          }
         },
         "is-glob": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+          }
         },
         "is-number": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          }
         },
         "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
           "dev": true
         },
         "is-primitive": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
           "dev": true
         },
         "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
           "dev": true
         },
         "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isobject": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
         },
         "istanbul-lib-coverage": {
-          "version": "1.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+          "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
           "dev": true
         },
         "istanbul-lib-hook": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+          "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
+          "dev": true,
+          "requires": {
+            "append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
+          }
         },
         "istanbul-lib-instrument": {
-          "version": "1.7.4",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
+          "integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
+          "dev": true,
+          "requires": {
+            "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+            "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+          }
         },
         "istanbul-lib-report": {
-          "version": "1.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+          "integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
           "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+          },
           "dependencies": {
             "supports-color": {
-              "version": "3.2.3",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "dev": true,
+              "requires": {
+                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+              }
             }
           }
         },
         "istanbul-lib-source-maps": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+          "integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
+          "dev": true,
+          "requires": {
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          }
         },
         "istanbul-reports": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+          "integrity": "sha1-BCvlyJ4XW8P4ZSPKqynAFOd/7k4=",
+          "dev": true,
+          "requires": {
+            "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz"
+          }
         },
         "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "jsesc": {
-          "version": "1.3.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
         },
         "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+          }
         },
         "load-json-file": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+          }
         },
         "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
+          "requires": {
+            "p-locate": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
+          },
           "dependencies": {
             "path-exists": {
-              "version": "3.0.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "dev": true
             }
           }
         },
         "lodash": {
-          "version": "4.17.4",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "longest": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "dev": true,
+          "requires": {
+            "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+          }
         },
         "lru-cache": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+          }
         },
         "md5-hex": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+          }
         },
         "md5-o-matic": {
-          "version": "0.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
+          }
         },
         "merge-source-map": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+          "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+          "dev": true,
+          "requires": {
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          }
         },
         "micromatch": {
-          "version": "2.3.11",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+          }
         },
         "mimic-fn": {
-          "version": "1.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
           "dev": true
         },
         "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+          }
         },
         "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          }
         },
         "ms": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+            "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+          }
         },
         "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+          }
         },
         "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
+          }
         },
         "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object.omit": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "dev": true,
+          "requires": {
+            "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+          }
         },
         "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         },
         "optimist": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+          }
         },
         "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
+          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
+          "dev": true,
+          "requires": {
+            "execa": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+            "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "mem": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz"
+          }
         },
         "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
-          "version": "1.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
           "dev": true
         },
         "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz"
+          }
         },
         "parse-glob": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+          "dev": true,
+          "requires": {
+            "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+          }
         },
         "parse-json": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+          }
         },
         "path-exists": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          }
         },
         "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
-          "version": "2.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
-          "version": "1.0.5",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          }
         },
         "pify": {
-          "version": "2.3.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+          }
         },
         "pkg-dir": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
+          "requires": {
+            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+          },
           "dependencies": {
             "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "dev": true,
+              "requires": {
+                "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+              }
             }
           }
         },
         "preserve": {
-          "version": "0.2.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
           "dev": true
         },
         "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "randomatic": {
-          "version": "1.1.7",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+          "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
           "dev": true,
+          "requires": {
+            "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+          },
           "dependencies": {
             "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
+              "requires": {
+                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+              },
               "dependencies": {
                 "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true
+                  "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                  }
                 }
               }
             },
             "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
             }
           }
         },
         "read-pkg": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+          }
         },
         "read-pkg-up": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
+          "requires": {
+            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+          },
           "dependencies": {
             "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "dev": true,
+              "requires": {
+                "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+              }
             }
           }
         },
         "regenerator-runtime": {
-          "version": "0.10.5",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
         },
         "regex-cache": {
-          "version": "0.4.3",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+          "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+          }
         },
         "remove-trailing-separator": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+          "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
           "dev": true
         },
         "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "repeating": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "dev": true,
+          "requires": {
+            "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+          }
         },
         "require-directory": {
-          "version": "2.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "right-align": {
-          "version": "0.1.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+          }
         },
         "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "dev": true,
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+          }
         },
         "semver": {
-          "version": "5.3.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
-          "version": "1.1.6",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "source-map": {
-          "version": "0.5.6",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         },
         "spawn-wrap": {
-          "version": "1.3.8",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.8.tgz",
+          "integrity": "sha1-+ip5uZDLsLsAGNymdI2INnsZ7DE=",
+          "dev": true,
+          "requires": {
+            "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+          }
         },
         "spdx-correct": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+          }
         },
         "spdx-expression-parse": {
-          "version": "1.0.4",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
           "dev": true
         },
         "spdx-license-ids": {
-          "version": "1.2.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
           "dev": true
         },
         "string-width": {
-          "version": "2.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
           "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+          },
           "dependencies": {
             "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+              }
             }
           }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+          }
         },
         "strip-bom": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+          }
         },
         "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+          "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
+          "dev": true,
+          "requires": {
+            "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+          }
         },
         "to-fast-properties": {
-          "version": "1.0.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         },
         "trim-right": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
         "uglify-js": {
-          "version": "2.8.29",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+          },
           "dependencies": {
             "yargs": {
-              "version": "3.10.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+              }
             }
           }
         },
         "uglify-to-browserify": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "validate-npm-package-license": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "dev": true,
+          "requires": {
+            "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+            "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+          }
         },
         "which": {
-          "version": "1.2.14",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "dev": true,
+          "requires": {
+            "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+          }
         },
         "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
-          "version": "0.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
-          "version": "0.0.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
+          "requires": {
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+          },
           "dependencies": {
             "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+              }
             }
           }
         },
         "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true
+          "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+          }
         },
         "y18n": {
-          "version": "3.2.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
-          "version": "2.1.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
-          "version": "8.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
+          },
           "dependencies": {
             "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             },
             "cliui": {
-              "version": "3.2.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
+              "requires": {
+                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+              },
               "dependencies": {
                 "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
+                  "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                  }
                 }
               }
             },
             "load-json-file": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+              }
             },
             "path-type": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+              "dev": true,
+              "requires": {
+                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+              }
             },
             "read-pkg": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+              "dev": true,
+              "requires": {
+                "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+                "path-type": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz"
+              }
             },
             "read-pkg-up": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+              "dev": true,
+              "requires": {
+                "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
+              }
             },
             "strip-bom": {
-              "version": "3.0.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
               "dev": true
             },
             "yargs-parser": {
-              "version": "7.0.0",
-              "bundled": true,
-              "dev": true
+              "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "dev": true,
+              "requires": {
+                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+              }
             }
           }
         },
         "yargs-parser": {
-          "version": "5.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+          },
           "dependencies": {
             "camelcase": {
-              "version": "3.0.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
               "dev": true
             }
           }
@@ -2316,16 +3345,35 @@
       }
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
+    "object-get-own-property-descriptor-x": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
+      "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
+      "dev": true,
+      "requires": {
+        "attempt-x": "1.1.0",
+        "has-own-property-x": "3.1.1",
+        "has-symbol-support-x": "1.4.1",
+        "is-falsey-x": "1.0.0",
+        "is-index-x": "1.0.0",
+        "is-primitive": "2.0.0",
+        "is-string": "1.0.4",
+        "property-is-enumerable-x": "1.1.0",
+        "to-object-x": "1.4.1",
+        "to-property-key-x": "2.0.1"
+      }
+    },
     "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -2343,35 +3391,41 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "path-array": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
       "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-index": "1.0.0"
+      }
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+      }
     },
     "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
     "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
     },
@@ -2380,12 +3434,36 @@
       "resolved": "https://registry.npmjs.org/pouchdb/-/pouchdb-6.3.4.tgz",
       "integrity": "sha512-+DSs6ipqj/SCIbEmIE6GZXYzem6YLkXPd2WBkoss5kM8P6VyNy8HUiQiYm6+NhLfchby941duXSWsejlqCuEYw==",
       "dev": true,
+      "requires": {
+        "argsarray": "0.0.1",
+        "buffer-from": "0.1.1",
+        "clone-buffer": "1.0.0",
+        "debug": "2.6.4",
+        "double-ended-queue": "2.1.0-0",
+        "immediate": "3.0.6",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "level-codec": "7.0.0",
+        "level-write-stream": "1.0.0",
+        "leveldown": "1.5.0",
+        "levelup": "1.3.8",
+        "lie": "3.1.1",
+        "ltgt": "2.2.0",
+        "readable-stream": "1.0.33",
+        "request": "2.80.0",
+        "spark-md5": "3.0.0",
+        "through2": "2.0.3",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+        "vuvuzela": "1.0.3"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
           "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.3"
+          }
         },
         "ms": {
           "version": "0.7.3",
@@ -2403,7 +3481,30 @@
           "version": "2.80.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.80.0.tgz",
           "integrity": "sha1-jMFi1215OBze/dNQXXa4C2BYm9A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+            "qs": "6.3.2",
+            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "tunnel-agent": "0.4.3",
+            "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+          }
         },
         "tunnel-agent": {
           "version": "0.4.3",
@@ -2417,25 +3518,58 @@
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/pouchdb-adapter-leveldb-core/-/pouchdb-adapter-leveldb-core-6.3.4.tgz",
       "integrity": "sha512-byrqd4pIaBE4YRa1UTyYOeQHDj/ceoFF+BBxeT4qb4HbV2wbp3lV9Fn39wH+WdtHoy2/ME+8uaHsmhi1vkClng==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argsarray": "0.0.1",
+        "buffer-from": "0.1.1",
+        "double-ended-queue": "2.1.0-0",
+        "levelup": "1.3.8",
+        "pouchdb-adapter-utils": "6.3.4",
+        "pouchdb-binary-utils": "6.3.4",
+        "pouchdb-collections": "6.3.4",
+        "pouchdb-errors": "6.3.4",
+        "pouchdb-json": "6.3.4",
+        "pouchdb-md5": "6.3.4",
+        "pouchdb-merge": "6.3.4",
+        "pouchdb-promise": "6.3.4",
+        "pouchdb-utils": "6.3.4",
+        "sublevel-pouchdb": "6.3.4",
+        "through2": "2.0.3"
+      }
     },
     "pouchdb-adapter-memory": {
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/pouchdb-adapter-memory/-/pouchdb-adapter-memory-6.3.4.tgz",
       "integrity": "sha512-9mQF1m1el2bdLDiZ5dbHpI6hcciqCaTOY0PX1jczUiAdB8SW+XiLyNZ52Pf+bo0tveDz/rbuRm7v4iZAtJ9rRQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "memdown": "1.2.4",
+        "pouchdb-adapter-leveldb-core": "6.3.4",
+        "pouchdb-utils": "6.3.4"
+      }
     },
     "pouchdb-adapter-utils": {
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/pouchdb-adapter-utils/-/pouchdb-adapter-utils-6.3.4.tgz",
       "integrity": "sha512-YXGpAKsHXl6A4HV+HMUJg7/ebM+ZtiGgQBSgUGuX5HETOaoczEP9yawLpiheAeQ727EeNM9MtVvCPeFFZAmqBA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pouchdb-binary-utils": "6.3.4",
+        "pouchdb-collections": "6.3.4",
+        "pouchdb-errors": "6.3.4",
+        "pouchdb-md5": "6.3.4",
+        "pouchdb-merge": "6.3.4",
+        "pouchdb-utils": "6.3.4"
+      }
     },
     "pouchdb-binary-utils": {
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-6.3.4.tgz",
       "integrity": "sha512-sjQwbtbg4yb6FOF1LJbdXlOVb2q7VImxxX2+8qsyrRyOzk9AdahTx/Ui4CVBPJO3w5M9HA52X0ou8eCsjtjEcg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-from": "0.1.1"
+      }
     },
     "pouchdb-collections": {
       "version": "6.3.4",
@@ -2447,19 +3581,29 @@
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.3.4.tgz",
       "integrity": "sha512-w96XRbS6hSFmCt+YmoUA2s6TsP8aUTteZ9BZ/Jjkcv5EdSlHwTKpmaBG5WG3givjCSmfP7+ZMCSDEop2PPcdqg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "pouchdb-json": {
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/pouchdb-json/-/pouchdb-json-6.3.4.tgz",
       "integrity": "sha512-Aqa3rYkbjKYPJO8ZJvdOBUkR8Y65JQKB7+O0krIk79jGOST1rx4phFQWnKRIKEqaHPcunFCf+Esy1qWANQaRsw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "vuvuzela": "1.0.3"
+      }
     },
     "pouchdb-md5": {
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-6.3.4.tgz",
       "integrity": "sha512-rd162ZigLEJZ6OotY6EJsM/hbWPTE5Dhr4WHTOJekv59n4Sp0/3Fq/MB5XFFfM6lZFrvuvd9Q6yzHwk4edemLw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pouchdb-binary-utils": "6.3.4",
+        "spark-md5": "3.0.0"
+      }
     },
     "pouchdb-merge": {
       "version": "6.3.4",
@@ -2471,19 +3615,52 @@
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.3.4.tgz",
       "integrity": "sha512-9kgpKXWFuFYJmhP7pjZvPhK9Lof8ipFVIoaZrFQN8HMep9/IdmhyXMUlISHkaNt3l0yWzW8bWYPg3OMocImvHA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lie": "3.1.1"
+      }
     },
     "pouchdb-utils": {
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.3.4.tgz",
       "integrity": "sha512-63mnIL7MX3ciyW1zWRl8OOUHZqRjeB1bC9kbFE+56F3U9T5OHMgkDcTukHRKXSfSnHPXoS+QujU3ups0SYsKIw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argsarray": "0.0.1",
+        "clone-buffer": "1.0.0",
+        "immediate": "3.0.6",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "pouchdb-collections": "6.3.4",
+        "pouchdb-errors": "6.3.4",
+        "pouchdb-promise": "6.3.4",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+      }
     },
     "prebuild": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-4.5.0.tgz",
       "integrity": "sha1-KqoN8gY7/4FKgDvU3JT/m2Tl3wA=",
       "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "execspawn": "1.0.1",
+        "expand-template": "1.1.0",
+        "ghreleases": "1.0.6",
+        "github-from-package": "0.0.0",
+        "minimist": "1.2.0",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "node-gyp": "3.6.2",
+        "node-ninja": "1.0.2",
+        "noop-logger": "0.1.1",
+        "npmlog": "2.0.4",
+        "os-homedir": "1.0.2",
+        "pump": "1.0.2",
+        "rc": "1.2.1",
+        "simple-get": "1.4.3",
+        "tar-fs": "1.15.3",
+        "tar-stream": "1.5.4",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -2500,10 +3677,19 @@
       "dev": true
     },
     "propagate": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+      "version": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
       "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
       "dev": true
+    },
+    "property-is-enumerable-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
+      "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
+      "dev": true,
+      "requires": {
+        "to-object-x": "1.4.1",
+        "to-property-key-x": "2.0.1"
+      }
     },
     "prr": {
       "version": "1.0.1",
@@ -2515,18 +3701,20 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
       "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      }
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "qs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+      "version": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+      "integrity": "sha1-jQSVTTZN7z78VbWgeT4eLIsebkk=",
       "dev": true
     },
     "rc": {
@@ -2534,6 +3722,12 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -2547,56 +3741,132 @@
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
       "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "string_decoder": "0.10.31"
+      }
     },
     "replace-comments-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-1.0.1.tgz",
-      "integrity": "sha512-FZLlrcoYb3Cb8bzPxiUTaMR7lm7ZTuUTovb6bHL+aMf41HnGgyRL+oABQ6KKoZo1JBt2UXZs5t2MI06ei2KupA==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-1.0.3.tgz",
+      "integrity": "sha512-9i7cX4w+QmkEAelyYVofBP+lLgJZkZ40imH9txxOQVX5F12vDccF+paHIQpDB2LNZY4gjkGbljintKCjUcflow==",
+      "dev": true,
+      "requires": {
+        "is-string": "1.0.4"
+      }
     },
     "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+        "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true
+        }
+      }
+    },
+    "require-object-coercible-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.1.tgz",
+      "integrity": "sha512-0YHa2afepsLfQvwQ1P2XvDZnGOUia5sC07ZijIRU2dnsRxnuilXWF6B2CFaKGDA9eZl39lJHrXCDsnfgroRd6Q==",
+      "dev": true,
+      "requires": {
+        "is-nil-x": "1.4.1"
+      }
     },
     "requizzle": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
+      "requires": {
+        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+      },
       "dependencies": {
         "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "version": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        }
+      }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
+    "safe-to-string-x": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.1.tgz",
+      "integrity": "sha512-CZEjtSlZnZXAa47Msj1HRp7dLO/qWJ17+7iTIg7D4Hy+hqhP7cSmhRrXE7huFDKXPmcSWtntte+KaEJCcRKaxw==",
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "1.4.1",
+        "is-symbol": "1.0.1",
+        "to-string-x": "1.4.1"
+      }
+    },
     "samsam": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+      "version": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
       "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
       "dev": true
     },
     "sift": {
@@ -2608,7 +3878,12 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
       "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "unzip-response": "1.0.2",
+        "xtend": "4.0.1"
+      }
     },
     "simple-mime": {
       "version": "0.1.0",
@@ -2617,22 +3892,32 @@
       "dev": true
     },
     "sinon": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
-      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
-      "dev": true
+      "version": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha1-Ah/WS1TLd9nS+w1Dze3652KcOjY=",
+      "dev": true,
+      "requires": {
+        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+        "formatio": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+        "lolex": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+        "native-promise-only": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+        "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+        "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+        "text-encoding": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
+      }
     },
     "sinon-chai": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.13.0.tgz",
-      "integrity": "sha512-hRNu/TlYEp4Rw5IbzO8ykGoZMSG489PGUx1rvePpHGrtl20cXivRBgtr/EWYxIwL9EOO9+on04nd9k3tW8tVww==",
+      "version": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.13.0.tgz",
+      "integrity": "sha1-uaQugBwgI0v8L0Oynm9PYbYJkMQ=",
       "dev": true
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      }
     },
     "spark-md5": {
       "version": "3.0.0",
@@ -2640,15 +3925,33 @@
       "integrity": "sha1-NyIifFTi+vJLHcbZM8wUTm9xv+8=",
       "dev": true
     },
+    "split-if-boxed-bug-x": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split-if-boxed-bug-x/-/split-if-boxed-bug-x-1.0.0.tgz",
+      "integrity": "sha512-EHUdMqDOpULook9NWmfKUN9G54wlHXXSMLVnfqXuiSNTwZC+2g+ay8Zmim5XUfPPP8FtGQeLS83v0pupQzI+Pg==",
+      "dev": true,
+      "requires": {
+        "has-boxed-string-x": "1.0.1",
+        "is-string": "1.0.4"
+      }
+    },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
+      "requires": {
+        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+      },
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -2661,14 +3964,12 @@
       "dev": true
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
@@ -2676,17 +3977,16 @@
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/sublevel-pouchdb/-/sublevel-pouchdb-6.3.4.tgz",
       "integrity": "sha512-3jnLcXF0QhN9UUNcRc+5tNZPTo9TQ1BMUlWygzsXlgnWCBKUwrvOXrKls0kk2cQ9myGh0R+5NZ7+H3D1lGKmZQ==",
-      "dev": true
-    },
-    "supports-color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "level-codec": "7.0.0",
+        "ltgt": "2.2.0",
+        "readable-stream": "1.0.33"
+      }
     },
     "taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "version": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
@@ -2694,19 +3994,36 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "tar-fs": {
       "version": "1.15.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
       "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chownr": "1.0.1",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "pump": "1.0.2",
+        "tar-stream": "1.5.4"
+      }
     },
     "tar-stream": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
       "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
       "dev": true,
+      "requires": {
+        "bl": "1.0.3",
+        "end-of-stream": "1.4.0",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -2718,19 +4035,30 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+          }
         }
       }
     },
     "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "version": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "through2": {
@@ -2738,6 +4066,10 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -2749,86 +4081,187 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+          }
         }
       }
     },
+    "to-integer-x": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz",
+      "integrity": "sha512-M9iETTi+xMMZtUC70q4VE63XL2mXmNABxwxsIebOfd8K4ZHKCJLD9GyE6RlEPnbOPZj21QinuoVkqWsBsBknRA==",
+      "dev": true,
+      "requires": {
+        "is-finite-x": "3.0.1",
+        "is-nan-x": "1.0.1",
+        "math-sign-x": "2.1.0",
+        "to-number-x": "1.1.0"
+      }
+    },
+    "to-length-x": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/to-length-x/-/to-length-x-2.1.0.tgz",
+      "integrity": "sha512-92jH0FU52g34/vMtGKuZS6xS7Ooo/6mOxbNNvbOfNDVgHUtQ9wAqConQ8YwAwVaVAwBt6O/WSeyY/DbBVLNCyg==",
+      "dev": true,
+      "requires": {
+        "max-safe-integer": "1.0.1",
+        "to-integer-x": "2.1.0"
+      }
+    },
+    "to-number-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.1.0.tgz",
+      "integrity": "sha512-m0v+VykgXsJ8JUSDKcvaASl977pSx5U1D6kyApFxP/KarJr7ZzVWrlHYTOxGDDodytsyh+iwZXpxBZpaWOvv4g==",
+      "dev": true,
+      "requires": {
+        "to-primitive-x": "1.0.1",
+        "trim-x": "1.0.3"
+      }
+    },
+    "to-object-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.4.1.tgz",
+      "integrity": "sha512-8Md/Q8E8Svkz/wQ2orCxN27OWKl2j6I5Ho7Wu0WzCB3XqzkRzLYP05grdm4BBB5978fggSKKOX4uBgZ/2wailA==",
+      "dev": true,
+      "requires": {
+        "require-object-coercible-x": "1.4.1"
+      }
+    },
+    "to-primitive-x": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.0.1.tgz",
+      "integrity": "sha512-2TJTFCZBdXtTBwvq+S63UnPVIlv0+zZMaka+n3ELhfSLqMB5aDhh2JmIKpzpvDigWQ45leukoAGBLCuIAeYkIA==",
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "1.4.1",
+        "is-date-object": "1.0.1",
+        "is-function-x": "3.1.1",
+        "is-nil-x": "1.4.1",
+        "is-primitive": "2.0.0",
+        "is-symbol": "1.0.1",
+        "require-object-coercible-x": "1.4.1",
+        "validate.io-undefined": "1.0.3"
+      }
+    },
+    "to-property-key-x": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.1.tgz",
+      "integrity": "sha512-ccIUkUCML03zRkNk+2k8jxzObOepBZiL9Z4qVeK0c0e/CXsvF8rVAhgnNe7W+qdCOSB8vcq/FTBZL6/ccGKfsg==",
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "1.4.1",
+        "to-primitive-x": "1.0.1",
+        "to-string-x": "1.4.1"
+      }
+    },
     "to-string-tag-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.0.tgz",
-      "integrity": "sha512-+hKRhsBP35H2Poucdg/lnHnV3OBwx9Ynz865ZBtdCY5kcgFzOVpGq2zjKHSvOaQDUk/FITmsDHRtCLYBi67vVA==",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-hPekHIGkkJowH45vGmYHLYe335PUnY0XAHa1tomdRpNVZT8wDsbWAbykRvJ81YKjyeBVN4smoNMLtJOWrQj7ZA==",
+      "dev": true,
+      "requires": {
+        "lodash.isnull": "3.0.0",
+        "validate.io-undefined": "1.0.3"
+      }
     },
     "to-string-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.0.tgz",
-      "integrity": "sha512-Wc3+16c087b3Oj8ycNLrdJmQPkGGMdtPdeDwsWhNwtTGnGClNdcqUuoZSq0d9br6qh9GDPtlCUjyhz8eIwPmZQ==",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.1.tgz",
+      "integrity": "sha512-63i4+t2/xWQCTYTTSFvQJcQzlXAL+0xLSJhOARh6XyDfv2AI5oKcQIVUQ9HwrbeHVLZ1fH+vWnoVLQpQIH/HaQ==",
+      "dev": true,
+      "requires": {
+        "is-symbol": "1.0.1"
+      }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+      }
     },
     "trim-left-x": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-1.3.3.tgz",
-      "integrity": "sha512-+BR0IT+4pQvoQemCY0j6D6aFs2W/9mpYuXMtPtTWjwd2Juq7JFlprBvLBJF6FdlEOkKneG4Zwc7zcf4Zdj7j1g==",
-      "dev": true
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-1.3.5.tgz",
+      "integrity": "sha512-aAp+6wECRhtaGWp44PKbxilvjY+kFPJ2RRweEtleLAZ9hYtM7DL1ShEPl/KF6lu6lAYb8xISF/h9egGjiJpZFQ==",
+      "dev": true,
+      "requires": {
+        "to-string-x": "1.4.1",
+        "white-space-x": "2.0.3"
+      }
     },
     "trim-right-x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-1.3.2.tgz",
-      "integrity": "sha512-BFpADj8aAgQb8+KSOEIC9KNZXCqybLA94F0lAnyXxF9D3P0IBzQ3/qPPGw3KkDV0uy38z75mHeGPq47Uucwvpw==",
-      "dev": true
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-1.3.3.tgz",
+      "integrity": "sha512-a0Moq+2fFdRXcVjqtDgxtDYx3bRTvsLMmwiK9vEVWuc8Y557oZjA3A6eJ0UcyNEa8DE57KMFSRGPUzrLLDJukg==",
+      "dev": true,
+      "requires": {
+        "to-string-x": "1.4.1",
+        "white-space-x": "2.0.3"
+      }
     },
     "trim-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-1.0.2.tgz",
-      "integrity": "sha512-jH5BwdQ+/sFqrKhJyJiX3wck5UVzZZbVOm7468zijazVddT9y5/gf+XlwHo9bOYhLPLsUbnsSivCT2G3dXcQJg==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-1.0.3.tgz",
+      "integrity": "sha512-+fXcHQ+pV3uL/wmuFZGL2uWh4hO7maqPf/534GyV4HAtVe/JE0IX4dFWNgYwGwqMvWztBSW6jrqQSslLggQbOg==",
+      "dev": true,
+      "requires": {
+        "trim-left-x": "1.3.5",
+        "trim-right-x": "1.3.3"
+      }
     },
     "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+      }
     },
     "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type-detect": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "version": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
       "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "version": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
     "underscore-contrib": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
       "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
       "dev": true,
+      "requires": {
+        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+      },
       "dependencies": {
         "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "version": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
@@ -2847,8 +4280,7 @@
       "dev": true
     },
     "urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "version": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
       "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
       "dev": true
     },
@@ -2865,9 +4297,8 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
       "dev": true
     },
     "validate.io-undefined": {
@@ -2877,14 +4308,17 @@
       "dev": true
     },
     "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "version": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+      },
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -2897,20 +4331,21 @@
       "dev": true
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true
+      "version": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "dev": true,
+      "requires": {
+        "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+      }
     },
     "white-space-x": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.2.tgz",
-      "integrity": "sha512-fFV+/CTimN5y1ivUbnnH1yL/D8WiXqK9IixeLlxXWMttTJWY6g40v7o+i0Q6wFH0eQ/IPo8fBH2CaquIwEDkxw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz",
+      "integrity": "sha512-An6uHDfZizY0t7x8iyY8nLej1lnqyaFSyTKjwwqS0VIhvV4tof6a+Et4uJVFlZh7HUAOgKoZfm5hFzl/D4xDgw==",
       "dev": true
     },
     "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -2919,6 +4354,9 @@
       "resolved": "https://registry.npmjs.org/write-stream/-/write-stream-0.4.3.tgz",
       "integrity": "sha1-g8yMA0fQr2BXqThitOOuAd5cgcE=",
       "dev": true,
+      "requires": {
+        "readable-stream": "0.0.4"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "0.0.4",
@@ -2929,8 +4367,7 @@
       }
     },
     "xmlcreate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
       "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2944 @@
+{
+  "name": "@trust/jwt",
+  "version": "0.4.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@trust/json-document": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@trust/json-document/-/json-document-0.1.4.tgz",
+      "integrity": "sha1-sgI7HhRbp2hb0fNux7aRKJQAc+k="
+    },
+    "@trust/jwa": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@trust/jwa/-/jwa-0.4.5.tgz",
+      "integrity": "sha1-6ASw6MMIxsDWaze9Wm56sb19E8I="
+    },
+    "@trust/jwk": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@trust/jwk/-/jwk-0.3.0.tgz",
+      "integrity": "sha1-SyWjSofYpUgBKBCE+F2ppH7WmmM="
+    },
+    "@trust/keyto": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-0.3.1.tgz",
+      "integrity": "sha1-Q96AKTD4JvxZj/73VtqBR42GEaM="
+    },
+    "@trust/webcrypto": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@trust/webcrypto/-/webcrypto-0.4.0.tgz",
+      "integrity": "sha1-zIcSyomn5x01P877ZrJwemec9jU="
+    },
+    "abbrev": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "dev": true
+    },
+    "abstract-leveldown": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.2.tgz",
+      "integrity": "sha512-6RmGuGZSsvwIYS9otANM+Rie7/6UNdE0IbxwUiXFjXmjHNCJZEjyX2Pltl5BvIYszLODlsnXtyA7A7Ujlca4Gw==",
+      "dev": true
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "dev": true
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true
+    },
+    "ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true
+        }
+      }
+    },
+    "argsarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz",
+      "integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs=",
+      "dev": true
+    },
+    "argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
+    },
+    "array-index": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
+      "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "asn1.js": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA="
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
+    },
+    "babylon": {
+      "version": "7.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.21.tgz",
+      "integrity": "sha512-fjhepTXb+WS5Iyu+DATZA5maLpuqaGckPnCgmnIWG80Xkm4SxA1mdTsBHMvaMSbdSKj/4Pocd4pUkI4qgL2wwQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true
+    },
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
+      "dev": true
+    },
+    "bl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+      "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "dev": true
+        }
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "dev": true
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
+      "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "catharsis": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
+      "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
+      "dev": true
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "codecov": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-2.3.0.tgz",
+      "integrity": "sha1-rSWixuBELRN0DZ1N27mj4nFDMPQ=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
+      "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
+      "dev": true,
+      "dependencies": {
+        "type-detect": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
+          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
+          "dev": true
+        }
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "dev": true
+    },
+    "deferred-leveldown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "dirty-chai": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
+      "integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
+      "dev": true
+    },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
+      "dev": true
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true
+    },
+    "elliptic": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+    },
+    "end-of-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "dev": true
+    },
+    "end-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/end-stream/-/end-stream-0.1.0.tgz",
+      "integrity": "sha1-MgA/P0OKKwFDFoE3+PpumGbIHtU=",
+      "dev": true
+    },
+    "errno": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "dev": true,
+      "dependencies": {
+        "prr": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+          "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+          "dev": true
+        }
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.30",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
+      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+      "dev": true
+    },
+    "es6-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "dev": true
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "execspawn": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/execspawn/-/execspawn-1.0.1.tgz",
+      "integrity": "sha1-gob53efOzeeQX73ATiTzaPI/jaY=",
+      "dev": true
+    },
+    "expand-template": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
+      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ==",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-future": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
+      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true
+    },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gauge": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+      "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "ghreleases": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ghreleases/-/ghreleases-1.0.6.tgz",
+      "integrity": "sha512-uySVPT5T9uP1xeWR7nl3WD8/JjJJXAph/0zdgUQJ7ovFpL3rxBT/HT0sO6w0GDWCj2gwXvzxBKrIeJAgBhs+fw==",
+      "dev": true
+    },
+    "ghrepos": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ghrepos/-/ghrepos-2.0.0.tgz",
+      "integrity": "sha1-1m6unZijtTmORg1tt+EKdCaS6Bs=",
+      "dev": true
+    },
+    "ghutils": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ghutils/-/ghutils-3.2.1.tgz",
+      "integrity": "sha1-T87f+sk1/KzgbhKhfGF04sKf/k8=",
+      "dev": true
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.0.tgz",
+      "integrity": "sha512-F1NtLDtW9NyUrS3faUcI1yVFHCTXyzPb1jfrZBQi5NHxFPlXxZnFLFGzfA2DsdmgCxv2MZ0+bfcgC4EZTmk4SQ==",
+      "dev": true
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.0.tgz",
+      "integrity": "sha512-R3OdOP9j6AH5hS1yXeu9wAS+iKSZQx/CC6aMdN6WiaqPlBoA2S+47MtoMsZgKr2m0eAJ+73WWGX0RaFFE5XWKA==",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
+    },
+    "hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA=="
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE="
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true
+    },
+    "hyperquest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
+      "integrity": "sha1-OeH+9miI3Hzg3sbA3YFPb8iUStU=",
+      "dev": true,
+      "dependencies": {
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "dev": true
+    },
+    "is-array-buffer-x": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.4.0.tgz",
+      "integrity": "sha512-0GQe5QPJBh9Lmt+PFP9O2BQvwQ1cMPohgL9vRuNIjb5cYi9HeeJESCJeG8lHziniVR+3VolF8YRz6LlfgNpb0A==",
+      "dev": true
+    },
+    "is-function-x": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.1.0.tgz",
+      "integrity": "sha512-QYIql/y+5SRlQyMCO93R+Gq3mPXkSy49MxsEuSu1DCoEx3UUuw+kbsPn7tGf1oStPchZBAqe20/xfqS1wZGSlQ==",
+      "dev": true
+    },
+    "is-object-like-x": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.0.tgz",
+      "integrity": "sha512-8nt2Uf/75/JWi0zL4cSesOkCKW/rcFtNiYi5776ny/LJCchPqheKnx/328MPUaN3uYzkSZKNjo7zbTGMpBfthw==",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "js2xmlparser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+      "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "jsdoc": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.4.tgz",
+      "integrity": "sha512-VmTw0J+2L16IxAe0JSDSAcH0F+DbZxaj8wN1AjHtKMQU/hO0ciIl5ZE93XqrrFIbknobuqHKJCXZj6+Hk57MjA==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonist": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-1.3.0.tgz",
+      "integrity": "sha1-wMdLle8clSA4YZsp76UgscyYdVY=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "klaw": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+      "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+      "dev": true
+    },
+    "level-codec": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.0.tgz",
+      "integrity": "sha1-x1W2jQ1E/6Cxy6BEuPgaVaFK05s=",
+      "dev": true
+    },
+    "level-errors": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "dev": true
+    },
+    "level-iterator-stream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+      "dev": true
+    },
+    "level-write-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/level-write-stream/-/level-write-stream-1.0.0.tgz",
+      "integrity": "sha1-P3+7Z5pVE3wP6zA97nZuEu4Twdw=",
+      "dev": true
+    },
+    "leveldown": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.5.0.tgz",
+      "integrity": "sha1-a408vqekqJqkdERgfXNYIT5vy4E=",
+      "dev": true
+    },
+    "levelup": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.8.tgz",
+      "integrity": "sha1-+0QsSI776hBD9+uZKaeSp0+9HaY=",
+      "dev": true,
+      "dependencies": {
+        "level-codec": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.1.0.tgz",
+          "integrity": "sha1-9d8KmVgvdtrEOFUVGrb05NDWAEU=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+          "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk=",
+          "dev": true
+        }
+      }
+    },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isnull": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
+      "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true
+    },
+    "lodash.pad": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
+      "dev": true
+    },
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "dev": true
+    },
+    "lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+      "dev": true
+    },
+    "ltgt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
+      "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI=",
+      "dev": true
+    },
+    "marked": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "dev": true
+    },
+    "memdown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.2.4.tgz",
+      "integrity": "sha1-zZo0qvB01TRFonEQjrS43U7A8n8=",
+      "dev": true,
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
+          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
+          "dev": true
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+          "dev": true
+        },
+        "ltgt": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+          "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=",
+          "dev": true
+        }
+      }
+    },
+    "mime-db": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+      "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true
+    },
+    "mocha": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+      "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI=",
+      "dev": true
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
+    },
+    "nock": {
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.14.tgz",
+      "integrity": "sha1-IhFVAlMXPOKYvNifyoJeg4E8pys=",
+      "dev": true,
+      "dependencies": {
+        "chai": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "dev": true
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "dev": true,
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+              "dev": true
+            }
+          }
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+          "dev": true
+        }
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
+      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig=="
+    },
+    "node-gyp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+      "dev": true,
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
+    "node-ninja": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-ninja/-/node-ninja-1.0.2.tgz",
+      "integrity": "sha1-IKCeV7kuLfWRmT1L8JisPnJwYrY=",
+      "dev": true
+    },
+    "node-rsa": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.4.2.tgz",
+      "integrity": "sha1-1jkXKewWqDDtWjgEKzFX0tXXJTA="
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true
+    },
+    "normalize-space-x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-1.3.2.tgz",
+      "integrity": "sha512-90FkeM1xmKZ47Kl0JY5PhTQCSfxxxPwqQyv744KRyoHi4Ulp9g9uWoygJR/Rdv1oklABuFnwgej1Y+fb+2pQjA==",
+      "dev": true
+    },
+    "npmlog": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+      "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
+      "dev": true
+    },
+    "nyc": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.1.0.tgz",
+      "integrity": "sha1-1rPF4WiSolr2MTi6SEZ2qooi7ac=",
+      "dev": true,
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-generator": {
+          "version": "6.25.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-template": {
+          "version": "6.25.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-traverse": {
+          "version": "6.25.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-types": {
+          "version": "6.25.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babylon": {
+          "version": "6.17.4",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "dev": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "dev": true
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "2.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.10",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.7.4",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-reports": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "merge-source-map": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "bundled": true,
+          "dev": true
+        },
+        "regex-cache": {
+          "version": "0.4.3",
+          "bundled": true,
+          "dev": true
+        },
+        "remove-trailing-separator": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.3.8",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "which": {
+          "version": "1.2.14",
+          "bundled": true,
+          "dev": true
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true,
+              "dev": true,
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "yargs-parser": {
+              "version": "7.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "dev": true
+    },
+    "path-array": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
+      "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "dev": true
+    },
+    "pouchdb": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb/-/pouchdb-6.3.4.tgz",
+      "integrity": "sha512-+DSs6ipqj/SCIbEmIE6GZXYzem6YLkXPd2WBkoss5kM8P6VyNy8HUiQiYm6+NhLfchby941duXSWsejlqCuEYw==",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+          "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.80.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.80.0.tgz",
+          "integrity": "sha1-jMFi1215OBze/dNQXXa4C2BYm9A=",
+          "dev": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
+        }
+      }
+    },
+    "pouchdb-adapter-leveldb-core": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-leveldb-core/-/pouchdb-adapter-leveldb-core-6.3.4.tgz",
+      "integrity": "sha512-byrqd4pIaBE4YRa1UTyYOeQHDj/ceoFF+BBxeT4qb4HbV2wbp3lV9Fn39wH+WdtHoy2/ME+8uaHsmhi1vkClng==",
+      "dev": true
+    },
+    "pouchdb-adapter-memory": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-memory/-/pouchdb-adapter-memory-6.3.4.tgz",
+      "integrity": "sha512-9mQF1m1el2bdLDiZ5dbHpI6hcciqCaTOY0PX1jczUiAdB8SW+XiLyNZ52Pf+bo0tveDz/rbuRm7v4iZAtJ9rRQ==",
+      "dev": true
+    },
+    "pouchdb-adapter-utils": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-utils/-/pouchdb-adapter-utils-6.3.4.tgz",
+      "integrity": "sha512-YXGpAKsHXl6A4HV+HMUJg7/ebM+ZtiGgQBSgUGuX5HETOaoczEP9yawLpiheAeQ727EeNM9MtVvCPeFFZAmqBA==",
+      "dev": true
+    },
+    "pouchdb-binary-utils": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-6.3.4.tgz",
+      "integrity": "sha512-sjQwbtbg4yb6FOF1LJbdXlOVb2q7VImxxX2+8qsyrRyOzk9AdahTx/Ui4CVBPJO3w5M9HA52X0ou8eCsjtjEcg==",
+      "dev": true
+    },
+    "pouchdb-collections": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.3.4.tgz",
+      "integrity": "sha512-F+o2SGRO5FZwoURVVcuj1hd94YN9DVr8sD/kg2pXhf2m/nJ2GfMiR4l88h9bh2VYb8BDNU3OQj6gXebzfxSwjA==",
+      "dev": true
+    },
+    "pouchdb-errors": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.3.4.tgz",
+      "integrity": "sha512-w96XRbS6hSFmCt+YmoUA2s6TsP8aUTteZ9BZ/Jjkcv5EdSlHwTKpmaBG5WG3givjCSmfP7+ZMCSDEop2PPcdqg==",
+      "dev": true
+    },
+    "pouchdb-json": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-json/-/pouchdb-json-6.3.4.tgz",
+      "integrity": "sha512-Aqa3rYkbjKYPJO8ZJvdOBUkR8Y65JQKB7+O0krIk79jGOST1rx4phFQWnKRIKEqaHPcunFCf+Esy1qWANQaRsw==",
+      "dev": true
+    },
+    "pouchdb-md5": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-6.3.4.tgz",
+      "integrity": "sha512-rd162ZigLEJZ6OotY6EJsM/hbWPTE5Dhr4WHTOJekv59n4Sp0/3Fq/MB5XFFfM6lZFrvuvd9Q6yzHwk4edemLw==",
+      "dev": true
+    },
+    "pouchdb-merge": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-merge/-/pouchdb-merge-6.3.4.tgz",
+      "integrity": "sha512-leejoseJNegA/hrEgEs3PeWAX800qM4+MuKYk24Jc2szY3VywinOzHMTv4sPeItRgAC6+9YG8CelC8F58525Jg==",
+      "dev": true
+    },
+    "pouchdb-promise": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.3.4.tgz",
+      "integrity": "sha512-9kgpKXWFuFYJmhP7pjZvPhK9Lof8ipFVIoaZrFQN8HMep9/IdmhyXMUlISHkaNt3l0yWzW8bWYPg3OMocImvHA==",
+      "dev": true
+    },
+    "pouchdb-utils": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.3.4.tgz",
+      "integrity": "sha512-63mnIL7MX3ciyW1zWRl8OOUHZqRjeB1bC9kbFE+56F3U9T5OHMgkDcTukHRKXSfSnHPXoS+QujU3ups0SYsKIw==",
+      "dev": true
+    },
+    "prebuild": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-4.5.0.tgz",
+      "integrity": "sha1-KqoN8gY7/4FKgDvU3JT/m2Tl3wA=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "propagate": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+      "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
+      "dev": true
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
+    },
+    "pump": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+      "dev": true
+    },
+    "rc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+      "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+      "dev": true
+    },
+    "replace-comments-x": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-1.0.1.tgz",
+      "integrity": "sha512-FZLlrcoYb3Cb8bzPxiUTaMR7lm7ZTuUTovb6bHL+aMf41HnGgyRL+oABQ6KKoZo1JBt2UXZs5t2MI06ei2KupA==",
+      "dev": true
+    },
+    "request": {
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "dev": true
+    },
+    "requizzle": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+      "dev": true,
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
+      }
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
+    },
+    "sift": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-5.0.0.tgz",
+      "integrity": "sha1-IS7LQQ2KUbg+fZaeSdU+ZZAoX/o="
+    },
+    "simple-get": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
+      "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
+      "dev": true
+    },
+    "simple-mime": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/simple-mime/-/simple-mime-0.1.0.tgz",
+      "integrity": "sha1-lfUXxPRm18/1YacfydqyWW6p7y4=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+      "dev": true
+    },
+    "sinon-chai": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.13.0.tgz",
+      "integrity": "sha512-hRNu/TlYEp4Rw5IbzO8ykGoZMSG489PGUx1rvePpHGrtl20cXivRBgtr/EWYxIwL9EOO9+on04nd9k3tW8tVww==",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true
+    },
+    "spark-md5": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.0.tgz",
+      "integrity": "sha1-NyIifFTi+vJLHcbZM8wUTm9xv+8=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "sublevel-pouchdb": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/sublevel-pouchdb/-/sublevel-pouchdb-6.3.4.tgz",
+      "integrity": "sha512-3jnLcXF0QhN9UUNcRc+5tNZPTo9TQ1BMUlWygzsXlgnWCBKUwrvOXrKls0kk2cQ9myGh0R+5NZ7+H3D1lGKmZQ==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true
+    },
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "dev": true
+    },
+    "tar-fs": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
+      "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
+      "dev": true
+    },
+    "tar-stream": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true
+        }
+      }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true
+        }
+      }
+    },
+    "to-string-tag-x": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.0.tgz",
+      "integrity": "sha512-+hKRhsBP35H2Poucdg/lnHnV3OBwx9Ynz865ZBtdCY5kcgFzOVpGq2zjKHSvOaQDUk/FITmsDHRtCLYBi67vVA==",
+      "dev": true
+    },
+    "to-string-x": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.0.tgz",
+      "integrity": "sha512-Wc3+16c087b3Oj8ycNLrdJmQPkGGMdtPdeDwsWhNwtTGnGClNdcqUuoZSq0d9br6qh9GDPtlCUjyhz8eIwPmZQ==",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "dev": true
+    },
+    "trim-left-x": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-1.3.3.tgz",
+      "integrity": "sha512-+BR0IT+4pQvoQemCY0j6D6aFs2W/9mpYuXMtPtTWjwd2Juq7JFlprBvLBJF6FdlEOkKneG4Zwc7zcf4Zdj7j1g==",
+      "dev": true
+    },
+    "trim-right-x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-1.3.2.tgz",
+      "integrity": "sha512-BFpADj8aAgQb8+KSOEIC9KNZXCqybLA94F0lAnyXxF9D3P0IBzQ3/qPPGw3KkDV0uy38z75mHeGPq47Uucwvpw==",
+      "dev": true
+    },
+    "trim-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-1.0.2.tgz",
+      "integrity": "sha512-jH5BwdQ+/sFqrKhJyJiX3wck5UVzZZbVOm7468zijazVddT9y5/gf+XlwHo9bOYhLPLsUbnsSivCT2G3dXcQJg==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "type-detect": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
+    "underscore-contrib": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+      "dev": true,
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
+      }
+    },
+    "unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+      "dev": true
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "dev": true
+    },
+    "urlgrey": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true
+    },
+    "validate.io-undefined": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
+      "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "vuvuzela": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vuvuzela/-/vuvuzela-1.0.3.tgz",
+      "integrity": "sha1-O+FF5YJxxzylUnndhR8SpoIRSws=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true
+    },
+    "white-space-x": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.2.tgz",
+      "integrity": "sha512-fFV+/CTimN5y1ivUbnnH1yL/D8WiXqK9IixeLlxXWMttTJWY6g40v7o+i0Q6wFH0eQ/IPo8fBH2CaquIwEDkxw==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write-stream": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/write-stream/-/write-stream-0.4.3.tgz",
+      "integrity": "sha1-g8yMA0fQr2BXqThitOOuAd5cgcE=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-0.0.4.tgz",
+          "integrity": "sha1-8y124/uGM0SlSNeZIwBxc2ZbO40=",
+          "dev": true
+        }
+      }
+    },
+    "xmlcreate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -40,12 +40,13 @@
   "homepage": "https://github.com/anvilresearch/jwt#README",
   "dependencies": {
     "@trust/json-document": "^0.1.4",
-    "@trust/jwa": "^0.4.4",
-    "@trust/jwk": "^0.3.0",
-    "@trust/webcrypto": "^0.4.0",
+    "@trust/jwa": "^0.4.6",
+    "@trust/jwk": "^0.3.1",
+    "@trust/webcrypto": "^0.5.0",
     "base64url": "^2.0.0"
   },
   "devDependencies": {
+    "@trust/keyto": "^0.3.1",
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",
     "codecov": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "mocha": "^3.5.0",
     "nock": "^9.0.14",
     "nyc": "^11.1.0",
+    "pouchdb": "^6.3.4",
+    "pouchdb-adapter-memory": "^6.3.4",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.12.0"
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@trust/json-document": "^0.1.4",
     "@trust/jwa": "^0.4.4",
-    "@trust/jwk": "^0.2.0",
+    "@trust/jwk": "^0.3.0",
     "@trust/webcrypto": "^0.4.0",
     "base64url": "^2.0.0"
   },

--- a/src/JOSESignature.js
+++ b/src/JOSESignature.js
@@ -91,7 +91,6 @@ class JOSESignature {
       cache,
       jwk
     } = options
-    console.log('OPTIONS', options)
 
     if (!payload) {
       return Promise.reject(

--- a/src/JOSESignature.js
+++ b/src/JOSESignature.js
@@ -1,0 +1,189 @@
+/**
+ * Dependencies
+ */
+const base64url = require('base64url')
+const { JWK } = require('@trust/jwk')
+const { DataError } = require('./errors')
+
+/**
+ * JOSE Signature
+ */
+class JOSESignature {
+
+  /**
+   * constructor
+   */
+  constructor (data = {}) {
+    let { protectedHeader, unprotectedHeader, signature, cache } = data
+
+    // copy properties to instance
+    //
+    // TODO (cs):
+    // - should this be a deep copy?
+    Object.assign(this, data)
+
+    // ensure integrity protected header
+    if (!protectedHeader) {
+      throw new DataError('JOSESignature must define protected header')
+    }
+
+    let { alg } = protectedHeader
+
+    // TODO
+    // ensure alg?
+
+    // ensure signature
+    if (!signature && alg !== 'none') {
+      throw new DataError('JOSESignature must define signature')
+    }
+
+    // ensure absence of signature
+    if (signature && alg === 'none') {
+      throw new DataError('Unsecured JWS must not include signature')
+    }
+
+    // ensure cache
+    if (!cache && alg !== 'none') {
+      throw new DataError('JOSESignature requires cache')
+    }
+
+    // TODO (cs):
+    // There has to be a less janky way to ensure the unprotected header
+    // is not added with undefined
+    if (this.hasOwnProperty('unprotectedHeader') &&
+        this['unprotectedHeader'] === undefined) {
+      delete this['unprotectedHeader']
+    }
+
+    // define cache as nonenumerable
+    delete this.cache
+    Object.defineProperty(this, 'cache', {
+      value: cache,
+      enumerable: false,
+      configurable: false
+    })
+
+    // make the object immutable
+    Object.freeze(this)
+  }
+
+  /**
+   * sign
+   *
+   * @description
+   * This method creates complete, finalized, immutable JOSESignature objects.
+   *
+   * @param {Object} options
+   * @param {Object} options.payload
+   * @param {Object} options.unprotectedHeader
+   * @param {Object} options.params
+   * @param {LRU} options.cache
+   * @param {JWK} options.jwk
+   *
+   * @returns {Promise<JOSESignature>}
+   */
+  static sign ({payload, unprotectedHeader, protectedHeaderParams, cache, jwk}) {
+    if (!payload) {
+      return Promise.reject(
+        new Error('Missing payload for JOSE Signature')
+      )
+    }
+
+    if (!cache) {
+      return Promise.reject(
+        new Error('Missing JWKSetCache for JOSE Signature')
+      )
+    }
+
+    // TODO (cs)
+    // ensure we have a suitable JWK instance, not just a value
+    if (!jwk) {
+      return Promise.reject(
+        new Error('JOSE Signature requires JWK')
+      )
+    }
+
+    let protectedHeader = jwk.getProtectedHeader(protectedHeaderParams)
+    let b64p = base64url(JSON.stringify(payload))
+    let b64h = base64url(JSON.stringify(protectedHeader))
+    let input = `${b64h}.${b64p}`
+
+    return jwk.sign(input)
+      .then(signature => new JOSESignature({
+        unprotectedHeader,
+        protectedHeader,
+        signature,
+        cache
+      }))
+  }
+
+  /**
+   * verify
+   *
+   * @description
+   * Verifies a JOSE Signature object for a given payload. If no key is provided,
+   * verify will try to get a key from the cache.
+   *
+   * @param {Object} payload
+   * @param {JWK|CryptoKey} keyHint
+   *
+   * @returns {Promise<Boolean>}
+   */
+  verify (payload, keyHint) {
+    let { protectedHeader, signature, cache } = this
+    let { alg, kid, jku, jwc } = protectedHeader
+
+    // Validate presence of "alg"
+    if (!alg) {
+      return Promise.reject(
+        new DataError('Missing "alg" in protected header')
+      )
+    }
+
+    // Invalid Unsecured JWS
+    // NOTE: this is convered in the constructor as well
+    //if (alg === 'none' && signature) {
+    //  return Promise.reject(
+    //    new GoFuckYourselfHNError()
+    //  )
+    //}
+
+    // Valid Unsecured JWS
+    if (alg === 'none') {
+      return Promise.resolve(true)
+    }
+
+    // Build the signing input for comparison
+    let b64h = base64url(JSON.stringify(protectedHeader))
+    let b64p = base64url(JSON.stringify(payload))
+    let signingInput = `${b64h}.${b64p}`
+
+    // explicitly passed a JWK instance with verify method
+    if (keyHint instanceof JWK) {
+      return keyHint.verify(signingInput, signature)
+    }
+
+    // passed a value for a single key that can be imported with JWK
+    // OR handle other usable key types such as CryptoKey
+    if (keyHint) {
+      return JWK.importKey(keyHint).then(jwk => this.verify(payload, jwk))
+    }
+
+    // certificate chain
+    if (Array.isArray(jwc)) {}
+
+    // certificate
+    if (jwc) {}
+
+    // remote jwk
+    if (kid && jku) {
+      return cache.getJwk(kid, jku).then(jwk => this.verify(payload, jwk))
+    }
+  }
+
+}
+
+/**
+ * Export
+ */
+module.exports = JOSESignature

--- a/src/JWKSetCache.js
+++ b/src/JWKSetCache.js
@@ -149,6 +149,8 @@ class JWKSetCache {
               throw err
             })
         }
+
+        return jwks
       })
       .catch(err => {
         // we don't care downstream *why* it couldn't be fetched?

--- a/src/JWKSetCache.js
+++ b/src/JWKSetCache.js
@@ -1,0 +1,242 @@
+'use strict'
+
+/**
+ * Dependencies
+ */
+const { JWKSet } = require('@trust/jwk')
+
+/**
+ * MAX
+ */
+const MAX = 100
+
+/**
+ * JWKSetCache
+ */
+class JWKSetCache {
+
+  /**
+   * constructor
+   */
+  constructor (options = {}) {
+    this.jwkSets = {}
+    this.recent = []
+    this.store = options.store || null
+    this.max = options.max || MAX
+  }
+
+  /**
+   * getJwk
+   *
+   * @description
+   * Gets a JWK identified by `kid` from a JWKSet identified
+   * by `jku`. May result in network request or database
+   * retrieval.
+   *
+   * @param {string} kid
+   * @param {string} jku
+   *
+   * @returns {Promise<JWK>}
+   */
+  getJwk (kid, jku) {
+    return Promise.resolve()
+      .then(() => this.getJwks(jku))
+      .then(jwks => this.getJwkFromJwks(jwks, jku, kid))
+  }
+
+  /**
+   * getJwks
+   *
+   * @description
+   * Gets a JWKSet idenfified by `jku`. May result in network
+   * request or database retrieval.
+   *
+   * @param {string} jku
+   * @returns {Promise<JWKSet>}
+   */
+  getJwks (jku) {
+    return Promise.resolve()
+      .then(() => this.getJwksFromCache(jku))
+      .then(jwks => this.getJwksFromStore(jwks, jku))
+      .then(jwks => this.getJwksFromNetwork(jwks, jku))
+      .then(jwks => this.cacheJwks(jwks))
+  }
+
+  /**
+   * getJwksFromCache
+   *
+   * @description
+   * Gets a JWKSet instance from in memory cache.
+   *
+   * @param {string} jku
+   * @returns {Promise<string|null>}
+   */
+  getJwksFromCache (jku) {
+    let cache = this.jwkSets
+    let jwks = cache[jku] || null
+
+    return Promise.resolve(jwks)
+  }
+
+  /**
+   * getJwksFromStore
+   *
+   * @description
+   * Gets a JWK Set from the database and import to
+   * JWKSet instance.
+   *
+   * @param {JWKSet|null} jwks
+   * @param {string} jku
+   *
+   * @return {Promise<JWKSet|null>}
+   */
+  getJwksFromStore (jwks, jku) {
+    let { store } = this
+
+    // pass through
+    if (jwks || !store) {
+      return Promise.resolve(jwks)
+    }
+
+    // get from the persisted cache
+    return store.get(jku).then(data => {
+      if (!data) { return null }
+      return JWKSet.importKeys(data)
+    })
+
+    // pouchdb rejects with a 404
+    .catch(err => {
+      if (err.status === 404) {
+        return null
+      }
+
+      throw err
+    })
+  }
+
+  /**
+   * getJwksFromNetwork
+   *
+   * @description
+   * Gets a JWK Set from the network and import to
+   * JWKSet instance.
+   *
+   * @param {JWKSet|null} jwks
+   *
+   */
+  getJwksFromNetwork (jwks, jku) {
+    let { store } = this
+
+    if (jwks) {
+      return Promise.resolve(jwks)
+    }
+
+    return JWKSet.importKeys(jku)
+      .then(jwks => {
+        let data = Object.assign({ _id: jku }, jwks)
+
+        if (store) {
+          return store.put(data)
+            .then(() => jwks)
+            .catch(err => {
+              if (err.status === 409) {
+                return store.get(jku).then(({_rev}) => {
+                  data._rev = _rev
+                  return store.put(data).then(() => jwks)
+                })
+              }
+
+              throw err
+            })
+        }
+      })
+      .catch(err => {
+        // we don't care downstream *why* it couldn't be fetched?
+        // only that we don't have a JWK Set...
+        // shouldn't interrupt program.
+        // paper over it? should we log something?
+        // JWKSet.importKeys should give typed error.
+        if (err.message.match('Failed to fetch remote JWKSet')) {
+          return null
+        }
+
+        throw err
+      })
+  }
+
+  /**
+   * cacheJwks
+   *
+   * @description
+   * Reorders the LRU Cache and removes least recently used items.
+   *
+   * @param {JWKSet|null} jwks
+   * @param {string} jku
+   *
+   * @returns {Promise<JWKSet>}
+   */
+  cacheJwks (jwks, jku) {
+    let { jwkSets, recent, max } = this
+
+    if (!jwks) {
+      return Promise.reject(new Error('JWK Set not found'))
+    }
+
+    if (recent.includes(jku)) {
+      recent.splice(recent.indexOf(jku))
+    }
+
+    recent.unshift(jku)
+    jwkSets[jku] = jwks
+
+    while (recent.length > max) {
+      let jku = recent.pop()
+      delete jwkSets[jku]
+    }
+
+    return Promise.resolve(jwks)
+  }
+
+  /**
+   * getJwkFromJwks
+   *
+   * @description
+   * Gets a JWK from a JWKSet by `kid`. If a JWK is not found
+   * in the JWKSet, such as may happen in the case of key rotation
+   * events, request from the network.
+   *
+   * @param {JWKSet} jwks
+   * @param {string} jku
+   * @param {string} kid
+   *
+   * @return {Promise<JWK>}
+   */
+  getJwkFromJwks (jwks, jku, kid) {
+    let jwk = jwks.find({ kid, key_ops: { $in: ['verify'] } })
+
+    // success
+    if (jwk) {
+      return Promise.resolve(jwk)
+    }
+
+    // try again
+    return Promise.resolve()
+      .then(() => this.getJwksFromNetwork(null, jku))
+      .then(jwks => this.cacheJwks(jwks, jku))
+      .then(jwks => {
+        let jwk = jwks.find({ kid, key_ops: { $in: ['verify'] } })
+
+        if (!jwk) {
+          throw new Error('JWK not found in JWK Set')
+        }
+
+        return jwk
+      })
+  }
+
+}
+
+/**
+ * Export
+ */
+module.exports = JWKSetCache

--- a/test/JOSESignatureSpec.js
+++ b/test/JOSESignatureSpec.js
@@ -30,7 +30,7 @@ const JWKSetCache = require('../src/JWKSetCache')
  * Tests
  * @ignore
  */
-describe.only('JOSESignature', () => {
+describe('JOSESignature', () => {
 
   /**
    * constructor

--- a/test/JOSESignatureSpec.js
+++ b/test/JOSESignatureSpec.js
@@ -1,0 +1,238 @@
+'use strict'
+
+/**
+ * Test dependencies
+ * @ignore
+ */
+const cwd = process.cwd()
+const path = require('path')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const nock = require('nock')
+
+/**
+ * Assertions
+ * @ignore
+ */
+chai.use(chaiAsPromised)
+chai.should()
+const expect = chai.expect
+
+/**
+ * Code Under Test
+ * @ignore
+ */
+const { JWKSet } = require('@trust/jwk')
+const JOSESignature = require('../src/JOSESignature')
+const JWKSetCache = require('../src/JWKSetCache')
+
+/**
+ * Tests
+ * @ignore
+ */
+describe.only('JOSESignature', () => {
+
+  /**
+   * constructor
+   */
+  describe('constructor', () => {
+    let cache, signature, joseSignature
+
+    beforeEach(() => {
+      cache = {}
+      signature = 'fake'
+      joseSignature = new JOSESignature({
+        foo: 'bar',
+        unprotectedHeader: { anything: 'goes' },
+        protectedHeader: { alg: 'RS256' },
+        signature,
+        cache
+      })
+    })
+
+    it('should ignore properties it does not understand', () => {
+      joseSignature.foo.should.equal('bar')
+      joseSignature.unprotectedHeader.anything.should.equal('goes')
+    })
+
+    it('should require integrity protected header', () => {
+      expect(() => {
+        new JOSESignature({
+          foo: 'bar',
+          unprotectedHeader: { anything: 'goes' },
+          signature,
+          cache
+        })
+      }).to.throw('JOSESignature must define protected header')
+    })
+
+    it('should not define empty unprotected header', () => {
+      joseSignature = new JOSESignature({
+        unprotectedHeader: undefined,
+        protectedHeader: { alg: 'RS256' },
+        signature,
+        cache
+      })
+
+      joseSignature.should.not.have.property('unprotectedHeader')
+    })
+
+    it('should require signature', () => {
+      expect(() => {
+        new JOSESignature({
+          foo: 'bar',
+          unprotectedHeader: { anything: 'goes' },
+          protectedHeader: { alg: 'RS256' },
+          cache
+        })
+      }).to.throw('JOSESignature must define signature')
+    })
+
+    it('should require absence of signature with unsecured JWS', () => {
+      expect(() => {
+        new JOSESignature({
+          protectedHeader: { alg: 'none' },
+          signature: 'nope'
+        })
+      }).to.throw('Unsecured JWS must not include signature')
+    })
+
+    it('should require JWK Set cache', () => {
+      expect(() => {
+        new JOSESignature({
+          foo: 'bar',
+          unprotectedHeader: { anything: 'goes' },
+          protectedHeader: { alg: 'RS256' },
+          signature
+        })
+      }).to.throw('JOSESignature requires cache')
+    })
+
+    it('should not require JWK Set cache with unsecured JWS', () => {
+      expect(() => {
+        new JOSESignature({
+          protectedHeader: { alg: 'none' }
+        })
+      }).to.not.throw()
+    })
+
+    it('should not enumerate cache property', () => {
+      JSON.stringify(joseSignature).should.not.include('"cache":')
+    })
+
+    it('should not include falsy unprotected header', () => {
+      joseSignature = new JOSESignature({
+        unprotectedHeader: undefined,
+        protectedHeader: { alg: 'none' }
+      })
+
+      expect(joseSignature).to.not.have.property('unprotectedHeader')
+    })
+
+    it('should freeze the instance', () => {
+      expect(() => {
+        joseSignature.x = 1
+      }).to.throw('is not extensible')
+    })
+  })
+
+  /**
+   * sign
+   */
+  describe('sign (static)', () => {
+    let jwk
+
+    before(() => {
+      return JWKSet.generateKeys('ES256').then(jwks => jwk = jwks.keys[0])
+    })
+
+    it('should reject with missing payload', () => {
+      return JOSESignature.sign({})
+        .should.be.rejectedWith('Missing payload for JOSE Signature')
+    })
+
+    it('should reject with missing JWK Set cache', () => {
+      return JOSESignature.sign({ payload: {} })
+        .should.be.rejectedWith('Missing JWKSetCache for JOSE Signature')
+    })
+
+    it('should reject with missing private key', () => {
+      return JOSESignature.sign({ payload: {}, cache: {} })
+        .should.be.rejectedWith('JOSE Signature requires JWK')
+    })
+
+    it('should resolve JOSESignature instance', () => {
+      return JOSESignature.sign({
+        payload: {},
+        protectedHeaderParams: {
+          kid: jwk.kid,
+          jku: 'https://example.com/jwks'
+        },
+        cache: {},
+        jwk
+      }).should.eventually.be.instanceOf(JOSESignature)
+    })
+
+  })
+
+  /**
+   * verify
+   */
+  describe('verify with kid and jku', () => {
+    let payload, joseSignature, jwks, jwk
+
+    beforeEach(() => {
+      return JWKSet.generateKeys('ES256').then(jwkSet => {
+        jwks = jwkSet
+        jwk = jwks.keys[1]
+        payload = { hello: 'world' }
+
+        return JOSESignature.sign({
+          payload,
+          protectedHeaderParams: {
+            kid: jwk.kid,
+            jku: 'https://example.com/jwks'
+          },
+          cache: new JWKSetCache(),
+          jwk: jwks.keys[0]
+        })
+        .then(sig => joseSignature = sig)
+      })
+    })
+
+    it('should reject with missing "alg" header parameter', () => {
+      delete joseSignature.protectedHeader.alg
+      return joseSignature.verify({ payload })
+        .should.be.rejectedWith('Missing "alg" in protected header')
+    })
+
+
+    it('should resolve "true" with valid unsecured JWS', () => {
+      joseSignature = new JOSESignature({
+        protectedHeader: { alg: 'none' }
+      })
+
+      return joseSignature.verify(payload)
+        .should.eventually.equal(true)
+    })
+
+    it('should resolve "true" with JWK and verifiable signature', () => {
+      let intercept = nock('https://example.com')
+        .get('/jwks')
+        .reply(200, jwks)
+
+      return joseSignature.verify(payload)
+        .should.eventually.equal(true)
+    })
+
+    it('should resolve "false" with JWK and unverifiable signature', () => {
+      let intercept = nock('https://example.com')
+        .get('/jwks')
+        .reply(200, jwks)
+
+      return joseSignature.verify({ hello: 'wrong' })
+        .should.eventually.equal(false)
+    })
+  })
+
+})

--- a/test/JOSESignatureSpec.js
+++ b/test/JOSESignatureSpec.js
@@ -43,8 +43,8 @@ describe('JOSESignature', () => {
       signature = 'fake'
       joseSignature = new JOSESignature({
         foo: 'bar',
-        unprotectedHeader: { anything: 'goes' },
-        protectedHeader: { alg: 'RS256' },
+        header: { anything: 'goes' },
+        protected: { alg: 'RS256' },
         signature,
         cache
       })
@@ -52,14 +52,14 @@ describe('JOSESignature', () => {
 
     it('should ignore properties it does not understand', () => {
       joseSignature.foo.should.equal('bar')
-      joseSignature.unprotectedHeader.anything.should.equal('goes')
+      joseSignature.header.anything.should.equal('goes')
     })
 
     it('should require integrity protected header', () => {
       expect(() => {
         new JOSESignature({
           foo: 'bar',
-          unprotectedHeader: { anything: 'goes' },
+          header: { anything: 'goes' },
           signature,
           cache
         })
@@ -68,21 +68,21 @@ describe('JOSESignature', () => {
 
     it('should not define empty unprotected header', () => {
       joseSignature = new JOSESignature({
-        unprotectedHeader: undefined,
-        protectedHeader: { alg: 'RS256' },
+        header: undefined,
+        protected: { alg: 'RS256' },
         signature,
         cache
       })
 
-      joseSignature.should.not.have.property('unprotectedHeader')
+      joseSignature.should.not.have.property('header')
     })
 
     it('should require signature', () => {
       expect(() => {
         new JOSESignature({
           foo: 'bar',
-          unprotectedHeader: { anything: 'goes' },
-          protectedHeader: { alg: 'RS256' },
+          header: { anything: 'goes' },
+          protected: { alg: 'RS256' },
           cache
         })
       }).to.throw('JOSESignature must define signature')
@@ -91,7 +91,7 @@ describe('JOSESignature', () => {
     it('should require absence of signature with unsecured JWS', () => {
       expect(() => {
         new JOSESignature({
-          protectedHeader: { alg: 'none' },
+          protected: { alg: 'none' },
           signature: 'nope'
         })
       }).to.throw('Unsecured JWS must not include signature')
@@ -101,8 +101,8 @@ describe('JOSESignature', () => {
       expect(() => {
         new JOSESignature({
           foo: 'bar',
-          unprotectedHeader: { anything: 'goes' },
-          protectedHeader: { alg: 'RS256' },
+          header: { anything: 'goes' },
+          protected: { alg: 'RS256' },
           signature
         })
       }).to.throw('JOSESignature requires cache')
@@ -111,7 +111,7 @@ describe('JOSESignature', () => {
     it('should not require JWK Set cache with unsecured JWS', () => {
       expect(() => {
         new JOSESignature({
-          protectedHeader: { alg: 'none' }
+          protected: { alg: 'none' }
         })
       }).to.not.throw()
     })
@@ -122,11 +122,11 @@ describe('JOSESignature', () => {
 
     it('should not include falsy unprotected header', () => {
       joseSignature = new JOSESignature({
-        unprotectedHeader: undefined,
-        protectedHeader: { alg: 'none' }
+        header: undefined,
+        protected: { alg: 'none' }
       })
 
-      expect(joseSignature).to.not.have.property('unprotectedHeader')
+      expect(joseSignature).to.not.have.property('header')
     })
 
     it('should freeze the instance', () => {
@@ -164,7 +164,7 @@ describe('JOSESignature', () => {
     it('should resolve JOSESignature instance', () => {
       return JOSESignature.sign({
         payload: {},
-        protectedHeaderParams: {
+        protected: {
           kid: jwk.kid,
           jku: 'https://example.com/jwks'
         },
@@ -189,7 +189,7 @@ describe('JOSESignature', () => {
 
         return JOSESignature.sign({
           payload,
-          protectedHeaderParams: {
+          protected: {
             kid: jwk.kid,
             jku: 'https://example.com/jwks'
           },
@@ -200,16 +200,9 @@ describe('JOSESignature', () => {
       })
     })
 
-    it('should reject with missing "alg" header parameter', () => {
-      delete joseSignature.protectedHeader.alg
-      return joseSignature.verify({ payload })
-        .should.be.rejectedWith('Missing "alg" in protected header')
-    })
-
-
     it('should resolve "true" with valid unsecured JWS', () => {
       joseSignature = new JOSESignature({
-        protectedHeader: { alg: 'none' }
+        protected: { alg: 'none' }
       })
 
       return joseSignature.verify(payload)

--- a/test/JWKSetCacheSpec.js
+++ b/test/JWKSetCacheSpec.js
@@ -1,0 +1,320 @@
+'use strict'
+
+/**
+ * Test dependencies
+ * @ignore
+ */
+const cwd = process.cwd()
+const path = require('path')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const nock = require('nock')
+
+/**
+ * Assertions
+ * @ignore
+ */
+chai.use(chaiAsPromised)
+chai.should()
+const expect = chai.expect
+
+/**
+ * Code Under Test
+ * @ignore
+ */
+const JWKSetCache = require('../src/JWKSetCache')
+const { JWKSet, JWK } = require('@trust/jwk')
+//const PouchDB = require('pouchdb')
+//PouchDB.plugin(require('pouchdb-adapter-memory'))
+
+/**
+ * Tests
+ * @ignore
+ */
+describe('JWKSetCache', () => {
+  let jwks
+
+  before(() => {
+    return JWKSet.generateKeys('ES256').then(result => jwks = result)
+  })
+
+  /**
+   * constructor
+   */
+  describe('constructor', () => {
+    let lru
+
+    beforeEach(() => {
+      lru = new JWKSetCache()
+    })
+
+    it('should initialize cache', () => {
+      lru.cache.should.be.instanceOf(Map)
+    })
+
+    it('should initialize default store', () => {
+      lru.store.should.be.instanceOf(PouchDB)
+    })
+
+    it('should initialize default max', () => {
+      lru.max.should.equal(25)
+    })
+
+    it('should initialize store from options', () => {
+      lru = new JWKSetCache({ store: new PouchDB('fake', { adapter: 'memory' }) })
+      lru.store.name.should.equal('fake')
+    })
+
+    it('should initialize max from options', () => {
+      lru = new JWKSetCache({ max: 100 })
+      lru.max.should.equal(100)
+    })
+  })
+
+  describe('getJwk', () => {
+    let lru, store, jku
+
+    beforeEach(() => {
+      store = new PouchDB('jwks', { adapter: 'memory' })
+      lru = new JWKSetCache({ store })
+      jku = 'https://example.com/jwks'
+
+      return store.post(Object.assign({ _id: jku }, jwks))
+    })
+
+    afterEach(() => {
+      return store.destroy()
+    })
+
+    it('should reject with invalid kid', () => {
+      let intercept = nock('https://example.com')
+        .get('/jwks')
+        .reply(200, jwks)
+
+      return lru.getJwk(jwks, jku, 'unknown')
+        .should.be.rejectedWith('JWK not found in JWK Set')
+    })
+
+    it('should reject with invalid jku', () => {
+      let intercept = nock('https://example.com')
+        .get('/unknown')
+        .reply(404, 'Not found')
+
+      return lru.getJwk(jwks, 'https://example.com/unknown', 'oughtabeok')
+        .should.be.rejectedWith('JWK Set not found')
+    })
+  })
+
+  describe('getJwks', () => {
+    let lru, store, jku
+
+    beforeEach(() => {
+      store = new PouchDB('jwks', { adapter: 'memory' })
+      lru = new JWKSetCache({ store })
+      jku = 'https://example.com/jwks'
+
+      //lru.cache.set(jku, jwks)
+      return store.post(Object.assign({ _id: jku }, jwks))
+    })
+
+    afterEach(() => {
+      return store.destroy()
+    })
+
+    it('should resolve a JWKSet', () => {
+      return lru.getJwks(jku)
+        .should.eventually.be.instanceOf(JWKSet)
+    })
+
+    it('should reject if not found', () => {
+      let intercept = nock('https://example.com')
+        .get('/unknown')
+        .reply(404, 'Not found')
+
+      return lru.getJwks('https://example.com/unknown')
+        .should.be.rejectedWith('JWK Set not found')
+    })
+  })
+
+  /**
+   * getJwksFromCache
+   */
+  describe('getJwksFromCache', () => {
+    let lru
+
+    before(() => {
+      lru = new JWKSetCache()
+      lru.cache.set('https://example.com/jwks', jwks)
+    })
+
+    it('should resolve cached JWK Set', () => {
+      return lru.getJwksFromCache('https://example.com/jwks')
+        .should.eventually.equal(jwks)
+    })
+
+    it('should resolve null if uncached', () => {
+      return lru.getJwksFromCache('https://unknown.com/jwks')
+        .should.eventually.equal(null)
+    })
+  })
+
+  describe('getJwksFromStore', () => {
+    let lru, store, jku
+
+    beforeEach(() => {
+      store = new PouchDB('jwks', { adapter: 'memory' })
+      lru = new JWKSetCache({ store })
+      jku = 'https://example.com/jwks'
+
+      return store.post(Object.assign({ _id: jku }, jwks))
+    })
+
+    afterEach(() => {
+      return store.destroy()
+    })
+
+    it('should resolve with provided JWK Set', () => {
+      return lru.getJwksFromStore(jwks, jku)
+        .should.eventually.equal(jwks)
+    })
+
+    it('should import JWK Set from data store', () => {
+      return lru.getJwksFromStore(null, jku)
+        .then(imported => {
+          imported.should.be.instanceOf(JWKSet)
+          expect(typeof imported['_id']).to.equal('string')
+          expect(typeof imported['_rev']).to.equal('string')
+          imported.keys.should.eql(jwks.keys)
+        })
+    })
+
+    it('should resolve null if JWK Set is not found', () => {
+      return lru.getJwksFromStore(null, 'https://unknown.com/jwks')
+        .should.eventually.equal(null)
+    })
+  })
+
+  describe('getJwksFromNetwork', () => {
+    let lru, store, jku
+
+    beforeEach(() => {
+      store = new PouchDB('jwks', { adapter: 'memory' })
+      lru = new JWKSetCache({ store })
+      jku = 'https://example.com/jwks'
+    })
+
+    afterEach(() => {
+      return store.destroy()
+    })
+
+    it('should resolve with provided JWK Set', () => {
+      return lru.getJwksFromNetwork(jwks, jku)
+        .should.eventually.equal(jwks)
+    })
+
+    it('should import JWK Set from jku', () => {
+      let intercept = nock('https://example.com')
+        .get('/jwks')
+        .reply(200, jwks)
+
+      return lru.getJwksFromNetwork(null, jku)
+        .should.eventually.eql(jwks)
+    })
+
+    it('should store imported JWK Set', () => {
+      let intercept = nock('https://example.com')
+        .get('/jwks')
+        .reply(200, jwks)
+
+      return lru.getJwksFromNetwork(null, jku)
+        .then(jwks => store.get(jku))
+        .then(data => data.keys.should.eql(jwks.keys))
+    })
+
+    it('should resolve imported JWK Set', () => {
+      let intercept = nock('https://example.com')
+        .get('/jwks')
+        .reply(200, jwks)
+
+      return lru.getJwksFromNetwork(null, jku)
+        .then(jwks => jwks.should.be.instanceOf(JWKSet))
+    })
+
+    it('should resolve null if JWK Set is not found', () => {
+      let intercept = nock('https://example.com')
+        .get('/jwks')
+        .reply(404, 'Not found')
+
+      return lru.getJwksFromNetwork(null, jku)
+        .should.eventually.equal(null)
+    })
+  })
+
+  /**
+   * cacheJwks
+   */
+  describe('cacheJwks', () => {
+    let lru, store, jku
+
+    beforeEach(() => {
+      store = new PouchDB('jwks', { adapter: 'memory' })
+      lru = new JWKSetCache({ store })
+      jku = 'https://example.com/jwks'
+    })
+
+    afterEach(() => {
+      return store.destroy()
+    })
+
+    it('should reject without jwks', () => {
+      return lru.cacheJwks(null, jku)
+        .should.be.rejectedWith('JWK Set not found')
+    })
+
+    it('should set new value to most recently used')
+    it('should set existing value to most recently used')
+    it('should remove least recently used items greater than maximum')
+
+    it('should eventually resolve a JWKSet', () => {
+      return lru.cacheJwks(jwks, jku)
+        .should.eventually.equal(jwks)
+    })
+  })
+
+  /**
+   * getJwkFromJwks
+   */
+  describe('getJwkFromJwks', () => {
+    let lru, store, jku, jwk
+
+    beforeEach(() => {
+      store = new PouchDB('jwks', { adapter: 'memory' })
+      lru = new JWKSetCache({ store })
+      jku = 'https://example.com/jwks'
+      jwk = jwks.find({ key_ops: { $in: ['verify'] } })
+
+      return store.post(Object.assign({ _id: jku }, jwks))
+    })
+
+    afterEach(() => {
+      return store.destroy()
+    })
+
+    it('should resolve JWK', () => {
+      return lru.getJwkFromJwks(jwks, jku, jwk.kid)
+        .should.eventually.equal(jwk)
+    })
+
+    it('should handle key rotation')
+
+    it('should reject with JWK not found in JWK Set', () => {
+      let intercept = nock('https://example.com')
+        .get('/jwks')
+        .reply(200, jwks)
+
+      return lru.getJwkFromJwks(jwks, jku, 'unknown')
+        .should.be.rejectedWith('JWK not found in JWK Set')
+    })
+  })
+
+})

--- a/test/jose/JWTSpec.js
+++ b/test/jose/JWTSpec.js
@@ -19,16 +19,16 @@ let expect = chai.expect
 const crypto = require('@trust/webcrypto')
 const { JWT } = require('../../src')
 const JWTSchema = require('../../src/schemas/JWTSchema')
-const { RsaPrivateCryptoKey, RsaPublicCryptoKey } = require('../keys')
+const { RsaPrivateJwk, RsaPublicJwk } = require('../keys')
 
 /**
  * Test data
  */
-const compact = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InI0bmQwbWJ5dDNzIn0.eyJpc3MiOiJodHRwczovL2ZvcmdlLmFudmlsLmlvIn0.FMer-lRR4Q4BVivMc9sl-jF3c-QWEenlH2pcW9oXTsiPRSEzc7lgPEryuXTimoToSKwWFgVpnjXKnmBaTaPVLpuRUMwGUeIUdQu0bQC-XEo-TKlwlqtUgelQcF2viEQwxU04UQaXWBh9ZDTIOutfXcjyhEPiMfCFLxT_aotR0zipmAi825lF1qBmxKrCv4c_9_46ACuaeuET6t0XvcAMDf3fjkEdw_0KPN2wnAlp2AwPP05D8Nwn8NqDAlljdN7bjnO99uJvhNWbvZgBYfhNXkMeDVJcukv0j3Cz6LCgedbXdX0rzJv_4qkO6l-LU9QeK1s0kwHfRUIWoa0TLJ4FtQ'
-const flattened = '{"payload":"eyJpc3MiOiJodHRwczovL2ZvcmdlLmFudmlsLmlvIn0","protected":"eyJhbGciOiJSUzI1NiIsImtpZCI6InI0bmQwbWJ5dDNzIn0","signature":"FMer-lRR4Q4BVivMc9sl-jF3c-QWEenlH2pcW9oXTsiPRSEzc7lgPEryuXTimoToSKwWFgVpnjXKnmBaTaPVLpuRUMwGUeIUdQu0bQC-XEo-TKlwlqtUgelQcF2viEQwxU04UQaXWBh9ZDTIOutfXcjyhEPiMfCFLxT_aotR0zipmAi825lF1qBmxKrCv4c_9_46ACuaeuET6t0XvcAMDf3fjkEdw_0KPN2wnAlp2AwPP05D8Nwn8NqDAlljdN7bjnO99uJvhNWbvZgBYfhNXkMeDVJcukv0j3Cz6LCgedbXdX0rzJv_4qkO6l-LU9QeK1s0kwHfRUIWoa0TLJ4FtQ"}'
-const json = '{"payload":"eyJpc3MiOiJodHRwczovL2ZvcmdlLmFudmlsLmlvIn0","signatures":[{"protected":"eyJhbGciOiJSUzI1NiIsImtpZCI6InI0bmQwbWJ5dDNzIn0","signature":"FMer-lRR4Q4BVivMc9sl-jF3c-QWEenlH2pcW9oXTsiPRSEzc7lgPEryuXTimoToSKwWFgVpnjXKnmBaTaPVLpuRUMwGUeIUdQu0bQC-XEo-TKlwlqtUgelQcF2viEQwxU04UQaXWBh9ZDTIOutfXcjyhEPiMfCFLxT_aotR0zipmAi825lF1qBmxKrCv4c_9_46ACuaeuET6t0XvcAMDf3fjkEdw_0KPN2wnAlp2AwPP05D8Nwn8NqDAlljdN7bjnO99uJvhNWbvZgBYfhNXkMeDVJcukv0j3Cz6LCgedbXdX0rzJv_4qkO6l-LU9QeK1s0kwHfRUIWoa0TLJ4FtQ"}]}'
+const compact = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InI0bmQwbWJ5dDNzIiwiamt1IjoiLi4uIn0.eyJpc3MiOiJodHRwczovL2ZvcmdlLmFudmlsLmlvIn0.Q9hLOSzGefpeN2rZ6NF1unA75Rmz0GMiwLorC5xJEY2keH0rgmO1nNF0wz4H7_8fUPylgKH6YkljRCiq8v9aaHZk4KXliaYHtntpNTKaqyEyJsKfa7b-Lr3Ysr8LAX_PoIVUk-mtD-A_vYE0iAedCDuSMcOWPRrvvZTDcFpolmvDLVkWs_xZTbKgkACGxSdy0c6wLx0u5A8uEGk05asNLMkNCLaKWbCS7L1wsg2at9ADs8hopeVfmQsHe9Z4HiYJe-iQUB-n_84beR0da4j810PxPgM24gOFdqd2jD1r645o9Gh4fNivx3Sexs5B8Gw__ESZYqq0zacZr5yHp4LCoQ'
+const flattened = '{"payload":"eyJpc3MiOiJodHRwczovL2ZvcmdlLmFudmlsLmlvIn0","protected":"eyJhbGciOiJSUzI1NiIsImtpZCI6InI0bmQwbWJ5dDNzIn0","signature":"Q9hLOSzGefpeN2rZ6NF1unA75Rmz0GMiwLorC5xJEY2keH0rgmO1nNF0wz4H7_8fUPylgKH6YkljRCiq8v9aaHZk4KXliaYHtntpNTKaqyEyJsKfa7b-Lr3Ysr8LAX_PoIVUk-mtD-A_vYE0iAedCDuSMcOWPRrvvZTDcFpolmvDLVkWs_xZTbKgkACGxSdy0c6wLx0u5A8uEGk05asNLMkNCLaKWbCS7L1wsg2at9ADs8hopeVfmQsHe9Z4HiYJe-iQUB-n_84beR0da4j810PxPgM24gOFdqd2jD1r645o9Gh4fNivx3Sexs5B8Gw__ESZYqq0zacZr5yHp4LCoQ"}'
+const json = '{"payload":"eyJpc3MiOiJodHRwczovL2ZvcmdlLmFudmlsLmlvIn0","signatures":[{"protected":"eyJhbGciOiJSUzI1NiIsImtpZCI6InI0bmQwbWJ5dDNzIn0","signature":"Q9hLOSzGefpeN2rZ6NF1unA75Rmz0GMiwLorC5xJEY2keH0rgmO1nNF0wz4H7_8fUPylgKH6YkljRCiq8v9aaHZk4KXliaYHtntpNTKaqyEyJsKfa7b-Lr3Ysr8LAX_PoIVUk-mtD-A_vYE0iAedCDuSMcOWPRrvvZTDcFpolmvDLVkWs_xZTbKgkACGxSdy0c6wLx0u5A8uEGk05asNLMkNCLaKWbCS7L1wsg2at9ADs8hopeVfmQsHe9Z4HiYJe-iQUB-n_84beR0da4j810PxPgM24gOFdqd2jD1r645o9Gh4fNivx3Sexs5B8Gw__ESZYqq0zacZr5yHp4LCoQ"}]}'
 
-const signature = 'FMer-lRR4Q4BVivMc9sl-jF3c-QWEenlH2pcW9oXTsiPRSEzc7lgPEryuXTimoToSKwWFgVpnjXKnmBaTaPVLpuRUMwGUeIUdQu0bQC-XEo-TKlwlqtUgelQcF2viEQwxU04UQaXWBh9ZDTIOutfXcjyhEPiMfCFLxT_aotR0zipmAi825lF1qBmxKrCv4c_9_46ACuaeuET6t0XvcAMDf3fjkEdw_0KPN2wnAlp2AwPP05D8Nwn8NqDAlljdN7bjnO99uJvhNWbvZgBYfhNXkMeDVJcukv0j3Cz6LCgedbXdX0rzJv_4qkO6l-LU9QeK1s0kwHfRUIWoa0TLJ4FtQ'
+const signature = 'Q9hLOSzGefpeN2rZ6NF1unA75Rmz0GMiwLorC5xJEY2keH0rgmO1nNF0wz4H7_8fUPylgKH6YkljRCiq8v9aaHZk4KXliaYHtntpNTKaqyEyJsKfa7b-Lr3Ysr8LAX_PoIVUk-mtD-A_vYE0iAedCDuSMcOWPRrvvZTDcFpolmvDLVkWs_xZTbKgkACGxSdy0c6wLx0u5A8uEGk05asNLMkNCLaKWbCS7L1wsg2at9ADs8hopeVfmQsHe9Z4HiYJe-iQUB-n_84beR0da4j810PxPgM24gOFdqd2jD1r645o9Gh4fNivx3Sexs5B8Gw__ESZYqq0zacZr5yHp4LCoQ'
 
 /**
  * Test data for JWE
@@ -300,7 +300,7 @@ describe('JWT', () => {
 
       it('should set JWT protected header', () => {
         JWT.decode(compact).signatures[0].should.have.property('protected')
-          .that.deep.equals({ alg: 'RS256', kid: 'r4nd0mbyt3s' })
+          .that.deep.equals({ alg: 'RS256', jku: '...', kid: 'r4nd0mbyt3s' })
       })
 
       it('should set JWT payload', () => {
@@ -439,22 +439,24 @@ describe('JWT', () => {
 
   describe('static sign', () => {
     it('should reject invalid parameters', (done) => {
-      JWT.sign(RsaPrivateCryptoKey, {
-        header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+      JWT.sign({
+        jwk: RsaPrivateJwk,
+        protected: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
         payload: { iss: null }
       }).should.be.rejected.and.notify(done)
     })
 
     it('should reject without payload', (done) => {
-      JWT.sign(RsaPrivateCryptoKey, {
-        header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+      JWT.sign({
+        jwk: RsaPrivateJwk,
+        protected: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
       }).should.be.rejected.and.notify(done)
     })
 
     it('should resolve a JWS', (done) => {
       JWT.sign({
-        cryptoKey: RsaPrivateCryptoKey,
-        header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+        jwk: RsaPrivateJwk,
+        protected: { alg: 'RS256', kid: 'r4nd0mbyt3s', jku: '...' },
         payload: { iss: 'https://forge.anvil.io' },
         serialization: 'compact'
       }).should.eventually.equal(compact).and.notify(done)
@@ -471,7 +473,8 @@ describe('JWT', () => {
 
   describe('static encrypt', () => {
     it('should reject invalid parameters', (done) => {
-      JWT.encrypt(RsaPublicCryptoKey, {
+      JWT.encrypt({
+        jwk: RsaPublicJwk,
         header: { enc: 'A128GCM' },
         plaintext: null
       }).should.be.rejected.and.notify(done)
@@ -495,7 +498,7 @@ describe('JWT', () => {
     })
 
     it('should reject invalid JWT', (done) => {
-      JWT.decrypt({ cryptoKey: RsaPublicCryptoKey, serialized: 'invalid' })
+      JWT.decrypt({ jwk: RsaPublicJwk, serialized: 'invalid' })
         .should.be.rejectedWith('Malformed JWT')
         .and.notify(done)
     })
@@ -523,54 +526,6 @@ describe('JWT', () => {
   })
 
   /**
-   * resolveKeys
-   */
-  describe.skip('resolveKeys', () => {
-    let jwks, token
-
-    beforeEach(() => {
-      jwks = {
-        keys: [
-          { kid: '123', cryptoKey: {} },
-          { use: 'sig', cryptoKey: {} }
-        ]
-      }
-
-      token = new JWT({
-        header: {
-          alg: 'RS256'
-        }
-      })
-    })
-
-    it('should throw with invalid argument', () => {
-      expect(() => {
-        token.resolveKeys(false)
-      }).to.throw('Invalid JWK argument')
-    })
-
-    it('should return true with match', () => {
-      token.resolveKeys(jwks).should.equal(true)
-    })
-
-    it('should return false with no match', () => {
-      token.header.kid = '234'
-      token.resolveKeys(jwks).should.equal(false)
-    })
-
-    it('should match JWK by `kid`', () => {
-      token.header.kid = '123'
-      token.resolveKeys(jwks)
-      token.key.should.equal(jwks.keys[0].cryptoKey)
-    })
-
-    it('should match JWK by `use`', () => {
-      token.resolveKeys(jwks)
-      token.key.should.equal(jwks.keys[1].cryptoKey)
-    })
-  })
-
-  /**
    * encode
    */
   describe('encode', () => {
@@ -579,8 +534,9 @@ describe('JWT', () => {
       class ExtendedJWT extends JWT {}
 
       it('should reject invalid JWS', (done) => {
-        ExtendedJWT.encode(RsaPrivateCryptoKey, {
-          header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+        ExtendedJWT.encode({
+          jwk: RsaPrivateJwk,
+          protected: { alg: 'RS256', kid: 'r4nd0mbyt3s', jku: '...' },
           payload: { iss: null }
         }).should.be.rejected.and.notify(done)
       })
@@ -595,8 +551,8 @@ describe('JWT', () => {
 
       it('should resolve a JWS Compact Serialization', (done) => {
         ExtendedJWT.encode({
-          cryptoKey: RsaPrivateCryptoKey,
-          header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+          jwk: RsaPrivateJwk,
+          protected: { alg: 'RS256', kid: 'r4nd0mbyt3s', jku: '...' },
           payload: { iss: 'https://forge.anvil.io' },
           serialization: 'compact'
         }).should.eventually.equal(compact).and.notify(done)
@@ -612,8 +568,8 @@ describe('JWT', () => {
 
       it('should filter JWS unspecified properties', () => {
         return ExtendedJWT.encode({
-          cryptoKey: RsaPrivateCryptoKey,
-          header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+          jwk: RsaPrivateJwk,
+          protected: { alg: 'RS256', kid: 'r4nd0mbyt3s', jku: '...' },
           payload: { iss: 'https://forge.anvil.io', foo: 'bar' },
           serialization: 'general'
         }).should.eventually.contain('eyJpc3MiOiJodHRwczovL2ZvcmdlLmFudmlsLmlvIn0')
@@ -630,8 +586,8 @@ describe('JWT', () => {
 
       it('should not filter unspecified properties when filter is false', () => {
         return JWT.encode({
-          cryptoKey: RsaPrivateCryptoKey,
-          header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+          jwk: RsaPrivateJwk,
+          protected: { alg: 'RS256', kid: 'r4nd0mbyt3s', jku: '...' },
           payload: { iss: 'https://forge.anvil.io', foo: 'bar' },
           serialization: 'general',
           filter: false
@@ -652,8 +608,8 @@ describe('JWT', () => {
 
     describe('with Base JWT', () => {
       it('should reject invalid JWS', (done) => {
-        JWT.encode(RsaPrivateCryptoKey, {
-          header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+        JWT.encode(RsaPrivateJwk, {
+          protected: { alg: 'RS256', kid: 'r4nd0mbyt3s', jku: '...' },
           payload: { iss: null }
         }).should.be.rejected.and.notify(done)
       })
@@ -667,8 +623,8 @@ describe('JWT', () => {
 
       it('should resolve a JWS Compact Serialization', (done) => {
         JWT.encode({
-          cryptoKey: RsaPrivateCryptoKey,
-          header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+          jwk: RsaPrivateJwk,
+          protected: { alg: 'RS256', kid: 'r4nd0mbyt3s', jku: '...' },
           payload: { iss: 'https://forge.anvil.io' },
           serialization: 'compact'
         }).should.eventually.equal(compact).and.notify(done)
@@ -684,8 +640,8 @@ describe('JWT', () => {
 
       it('should not filter JWS unspecified properties', () => {
         return JWT.encode({
-          cryptoKey: RsaPrivateCryptoKey,
-          header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+          jwk: RsaPrivateJwk,
+          protected: { alg: 'RS256', kid: 'r4nd0mbyt3s', jku: '...' },
           payload: { iss: 'https://forge.anvil.io', foo: 'bar' },
           serialization: 'general'
         }).should.eventually.contain('eyJpc3MiOiJodHRwczovL2ZvcmdlLmFudmlsLmlvIiwiZm9vIjoiYmFyIn0')
@@ -702,8 +658,8 @@ describe('JWT', () => {
 
       it('should filter JWS unspecified properties when filter is true', () => {
         return JWT.encode({
-          cryptoKey: RsaPrivateCryptoKey,
-          header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+          jwk: RsaPrivateJwk,
+          protected: { alg: 'RS256', kid: 'r4nd0mbyt3s', jku: '...' },
           payload: { iss: 'https://forge.anvil.io', foo: 'bar' },
           serialization: 'general',
           filter: true
@@ -727,18 +683,18 @@ describe('JWT', () => {
    */
   describe('verify', () => {
     it('should reject invalid JWT', (done) => {
-      JWT.verify({ cryptoKey: RsaPublicCryptoKey, serialized: 'invalid' })
+      JWT.verify({ jwk: RsaPublicJwk, serialized: 'invalid' })
         .should.be.rejectedWith('Malformed JWT')
         .and.notify(done)
     })
 
     it('should resolve a boolean', (done) => {
-      JWT.verify({ cryptoKey: RsaPublicCryptoKey, serialized: compact })
+      JWT.verify({ jwk: RsaPublicJwk, serialized: compact })
         .should.eventually.equal(true).and.notify(done)
     })
 
     it('can resolve an instance', (done) => {
-      JWT.verify({ cryptoKey: RsaPublicCryptoKey, serialized: compact, result: 'instance' })
+      JWT.verify({ jwk: RsaPublicJwk, serialized: compact, result: 'instance' })
         .should.eventually.be.instanceof(JWT).and.notify(done)
     })
   })

--- a/test/keys/index.js
+++ b/test/keys/index.js
@@ -44,7 +44,8 @@ const RsaPrivateJwk = {
   q: 't9vB-yjoWydrBXy5q4m0pMcTm9FZum9kahCXx_0QjYPLjxwX6-d8Tc1Y1_VROtQDAIxuyMZxkboQ0L8uXtVQCjVz8hG1UDeqzISxLyTVP-JtD6yijhyrtQdgtokgAFzBHpYaMKgr8tARtojF5EyWPTQJpBSI2-tl0GgwEOa3Gz0',
   dp: 'euUkC1wjaTfkQ5ftqW8Ws64wb5vDMdJz3aoiBUm5XISrHSTbz_e3AW894_R2ECxrsrnZVB2xj8_y8nGZTQxOogRDKq6ixct92qyF6WV5KHG2fP-gnElD8n4QAYIFqK8p9C5yyBuJOzza4Npou-5i1AfuFHTW5i1JdluuoefF4iE',
   dq: 'MbqQxxwTbMRGoB9SIOGIKKFn3ldLi6-hW0bNptv95Cjnn_ebSMU9y9Vk2FST-fNqNHXHaSqzgRTwg2WSZzgPBBPdHnZHskC8Q8EII5Y0z6iwkvLArOt4TeiG8hg4vaBY46r5vnteF7jLcbGgxNUqNbeje-vJ8KHE0g-8IHYmxIk',
-  qi: 'lXeBzCAWAADq3ybuDhhK0MoA0meC2118dkLUiEYU60o9z-ud6huAMK3jyDD1tAPyDLzuVpFv-GOb_QDPhuO0MM6QpjnKEJS2KmenHgVHXacZGYx9EZ50smGut2WSeLznfu9SXavCIbdTctOL28cwhsFB6TmvGVtzyNLx6MZQV1w'
+  qi: 'lXeBzCAWAADq3ybuDhhK0MoA0meC2118dkLUiEYU60o9z-ud6huAMK3jyDD1tAPyDLzuVpFv-GOb_QDPhuO0MM6QpjnKEJS2KmenHgVHXacZGYx9EZ50smGut2WSeLznfu9SXavCIbdTctOL28cwhsFB6TmvGVtzyNLx6MZQV1w',
+  key_ops: ['sign']
 }
 
 /**
@@ -53,7 +54,7 @@ const RsaPrivateJwk = {
 const RsaPrivateCryptoKey = new CryptoKey({
   type: 'private',
   algorithm: { name: 'RSASSA-PKCS1-v1_5' },
-  extractable: false,
+  extractable: true,
   usages: ['sign'],
   handle: RsaPrivateKey
 })
@@ -78,7 +79,9 @@ BQIDAQAB
 const RsaPublicJwk = {
   kty: 'RSA',
   n: 'iEJoO1tBT1Yc9jdYWI5JUkMnOlFD-weoi1rkxsWvZoBRJJGifjrdmIn_5xOaaW38Cg535lo6NEorsVsq7V6zGan2QCT1TRCb7vJq4UIEq6tL5uB0BZMyByKBYDKVGAinXYd502nJ1T7sbZQnSjZFC3HgDvrqb_4bDIbO0-sAiaTumt-2uyIYcGYBuIfTi8vmElz2ngUFh-8K_uQyH7YjrOrg6ThOldh8IVzaOSA7LAb_DjyC-H44F_J24qMRLGuWK53gz-2RazSBotiNUsGoxdZv30Sud3Yfbz9ZjSXxPWpRnG6mZAZW76oSbn8FvTSTWrf0iU6MyNkv_QuAjF-1BQ',
-  e: 'AQAB'
+  e: 'AQAB',
+  alg: 'RS256',
+  key_ops: ['verify']
 }
 
 /**


### PR DESCRIPTION
A continuation of work done by @christiansmith on the `JWKSetCache` and `JOSESignature` classes.

Everything is hooked up and the tests are passing.

@dmitrizagidulin: this also messes with the API a little but in most cases it should work as before -- mostly adds new API functionality in anticipation of JWC.

Also added a couple of examples.